### PR TITLE
Convenience function for pipeline initialization; updated tests

### DIFF
--- a/Spokestack/SpeechPipeline.swift
+++ b/Spokestack/SpeechPipeline.swift
@@ -57,24 +57,25 @@ import Foundation
     /// - Parameter speechDelegate: An implementation of `SpeechEventListener`.
     /// - Parameter pipelineDelegate: An implementation of `PipelineDelegate`.
     @objc public init(_ speechDelegate: SpeechEventListener,
-                      pipelineDelegate: PipelineDelegate) throws {
+                      pipelineDelegate: PipelineDelegate) {
+        let c = SpeechConfiguration()
         self.speechConfiguration = SpeechConfiguration()
         self.speechDelegate = speechDelegate
         
         self.speechRecognizerService = SpeechProcessors.appleSpeech.processor
         /// order is important: set the delegate first so that configuration errors/tracing can be sent back
         self.speechRecognizerService.delegate = self.speechDelegate
-        self.speechRecognizerService.configuration = SpeechConfiguration()
+        self.speechRecognizerService.configuration = c
         self.wakewordRecognizerService = SpeechProcessors.appleWakeword.processor
         /// see previous comment
         self.wakewordRecognizerService.delegate = self.speechDelegate
-        self.wakewordRecognizerService.configuration = speechConfiguration
+        self.wakewordRecognizerService.configuration = c
         
-        AudioController.sharedInstance.configuration = SpeechConfiguration()
+        AudioController.sharedInstance.configuration = c
         
         self.pipelineDelegate = pipelineDelegate
         AudioController.sharedInstance.pipelineDelegate = self.pipelineDelegate
-        self.pipelineDelegate!.didInit()
+        self.pipelineDelegate?.didInit()
     }
     
     /// Initializes a new speech pipeline instance.
@@ -87,7 +88,7 @@ import Foundation
                       speechConfiguration: SpeechConfiguration,
                       speechDelegate: SpeechEventListener,
                       wakewordService: SpeechProcessor,
-                      pipelineDelegate: PipelineDelegate) throws {
+                      pipelineDelegate: PipelineDelegate) {
         self.speechConfiguration = speechConfiguration
         self.speechDelegate = speechDelegate
         
@@ -104,7 +105,7 @@ import Foundation
         
         self.pipelineDelegate = pipelineDelegate
         AudioController.sharedInstance.pipelineDelegate = self.pipelineDelegate
-        self.pipelineDelegate!.didInit()
+        self.pipelineDelegate?.didInit()
     }
     
     /// Checks the status of the delegates provided in the constructor.

--- a/Spokestack/SpeechPipeline.swift
+++ b/Spokestack/SpeechPipeline.swift
@@ -53,6 +53,30 @@ import Foundation
         wakewordRecognizerService.delegate = nil
     }
     
+    /// Initializes a new speech pipeline instance with reasonable defaults for configuration, wakeword, and asr recognizers.
+    /// - Parameter speechDelegate: An implementation of `SpeechEventListener`.
+    /// - Parameter pipelineDelegate: An implementation of `PipelineDelegate`.
+    @objc public init(_ speechDelegate: SpeechEventListener,
+                      pipelineDelegate: PipelineDelegate) throws {
+        self.speechConfiguration = SpeechConfiguration()
+        self.speechDelegate = speechDelegate
+        
+        self.speechRecognizerService = SpeechProcessors.appleSpeech.processor
+        /// order is important: set the delegate first so that configuration errors/tracing can be sent back
+        self.speechRecognizerService.delegate = self.speechDelegate
+        self.speechRecognizerService.configuration = SpeechConfiguration()
+        self.wakewordRecognizerService = SpeechProcessors.appleWakeword.processor
+        /// see previous comment
+        self.wakewordRecognizerService.delegate = self.speechDelegate
+        self.wakewordRecognizerService.configuration = speechConfiguration
+        
+        AudioController.sharedInstance.configuration = SpeechConfiguration()
+        
+        self.pipelineDelegate = pipelineDelegate
+        AudioController.sharedInstance.pipelineDelegate = self.pipelineDelegate
+        self.pipelineDelegate!.didInit()
+    }
+    
     /// Initializes a new speech pipeline instance.
     /// - Parameter speechService: An implementation of `SpeechProcessor`.
     /// - Parameter speechConfiguration: Configuration parameters for the speech pipeline.
@@ -71,8 +95,6 @@ import Foundation
         /// order is important: set the delegate first so that configuration errors/tracing can be sent back
         self.speechRecognizerService.delegate = self.speechDelegate
         self.speechRecognizerService.configuration = speechConfiguration
-        
-        
         self.wakewordRecognizerService = wakewordService
         /// see previous comment
         self.wakewordRecognizerService.delegate = self.speechDelegate

--- a/SpokestackFrameworkExample/AppleASRViewController.swift
+++ b/SpokestackFrameworkExample/AppleASRViewController.swift
@@ -47,11 +47,11 @@ class AppleASRViewController: UIViewController {
         
         let appleConfiguration: SpeechConfiguration = SpeechConfiguration()
         
-        return try! SpeechPipeline(SpeechProcessors.appleSpeech.processor,
-                                   speechConfiguration: appleConfiguration,
-                                   speechDelegate: self,
-                                   wakewordService: SpeechProcessors.appleWakeword.processor,
-                                   pipelineDelegate: self)
+        return SpeechPipeline(SpeechProcessors.appleSpeech.processor,
+                              speechConfiguration: appleConfiguration,
+                              speechDelegate: self,
+                              wakewordService: SpeechProcessors.appleWakeword.processor,
+                              pipelineDelegate: self)
     }()
     
     override func loadView() {

--- a/SpokestackFrameworkExample/AppleWakewordViewController.swift
+++ b/SpokestackFrameworkExample/AppleWakewordViewController.swift
@@ -51,12 +51,11 @@ class AppleWakewordViewController: UIViewController {
     lazy public var pipeline: SpeechPipeline = {
         let c = SpeechConfiguration()
         c.tracing = Trace.Level.DEBUG
-        return try!
-            SpeechPipeline(SpeechProcessors.appleSpeech.processor,
-                                   speechConfiguration: c,
-                                   speechDelegate: self,
-                                   wakewordService: SpeechProcessors.appleWakeword.processor,
-                                   pipelineDelegate: self)
+        return SpeechPipeline(SpeechProcessors.appleSpeech.processor,
+                              speechConfiguration: c,
+                              speechDelegate: self,
+                              wakewordService: SpeechProcessors.appleWakeword.processor,
+                              pipelineDelegate: self)
     }()
     
     override func loadView() {

--- a/SpokestackFrameworkExample/CoreMLViewController.swift
+++ b/SpokestackFrameworkExample/CoreMLViewController.swift
@@ -88,11 +88,11 @@ class CoreMLViewController: UIViewController {
         }
         c.detectModelPath = detectPath
         c.tracing = Trace.Level.PERF
-        return try! SpeechPipeline(SpeechProcessors.appleSpeech.processor,
-                                   speechConfiguration: c,
-                                   speechDelegate: self,
-                                   wakewordService: SpeechProcessors.coremlWakeword.processor,
-                                   pipelineDelegate: self)
+        return SpeechPipeline(SpeechProcessors.appleSpeech.processor,
+                              speechConfiguration: c,
+                              speechDelegate: self,
+                              wakewordService: SpeechProcessors.coremlWakeword.processor,
+                              pipelineDelegate: self)
     }
     
     @objc func startRecordingAction(_ sender: Any) {

--- a/SpokestackFrameworkExample/TFLiteViewController.swift
+++ b/SpokestackFrameworkExample/TFLiteViewController.swift
@@ -92,11 +92,11 @@ class TFLiteViewController: UIViewController {
         }
         c.detectModelPath = detectPath
         c.tracing = Trace.Level.PERF
-        return try! SpeechPipeline(SpeechProcessors.appleSpeech.processor,
-                                   speechConfiguration: c,
-                                   speechDelegate: self,
-                                   wakewordService: SpeechProcessors.tfLiteWakeword.processor,
-                                   pipelineDelegate: self)
+        return SpeechPipeline(SpeechProcessors.appleSpeech.processor,
+                              speechConfiguration: c,
+                              speechDelegate: self,
+                              wakewordService: SpeechProcessors.tfLiteWakeword.processor,
+                              pipelineDelegate: self)
     }
     
     @objc func startRecordingAction(_ sender: Any) {

--- a/SpokestackTests/SpeechPipelineTest.swift
+++ b/SpokestackTests/SpeechPipelineTest.swift
@@ -17,18 +17,11 @@ class SpeechPipelineTest: XCTestCase {
         let delegate = SpeechPipelineTestDelegate()
         let didInitExpectation = expectation(description: "testInit calls SpeechPipelineTestDelegate as the result of didInit method completion")
         delegate.asyncExpectation = didInitExpectation
-        
-        do {
-            /// successful init calls didInit
-            try SpeechPipeline(delegate, pipelineDelegate: delegate)
-            wait(for: [didInitExpectation], timeout: 1)
-            XCTAssert(delegate.didDidInit)
-            
-        } catch let error {
-            XCTFail(error.localizedDescription)
-        }
-        
-        /// NB init is marked as throws because it force-unwraps the pipelineDelegate, but since the pipelineDelegate is required in the constructor, init cannot actually throw.
+
+        /// successful init calls didInit
+        _ = SpeechPipeline(delegate, pipelineDelegate: delegate)
+        wait(for: [didInitExpectation], timeout: 1)
+        XCTAssert(delegate.didDidInit)
     }
     
     /// init
@@ -38,20 +31,14 @@ class SpeechPipelineTest: XCTestCase {
         delegate.asyncExpectation = didInitExpectation
         let config = SpeechConfiguration()
         config.fftHopLength = 30
+
+        /// successful init calls didInit
+        let p = SpeechPipeline(TestProcessor(true), speechConfiguration: config, speechDelegate: delegate, wakewordService: TestProcessor(), pipelineDelegate: delegate)
+        wait(for: [didInitExpectation], timeout: 1)
+        XCTAssert(delegate.didDidInit)
         
-        do {
-            /// successful init calls didInit
-            let p = try SpeechPipeline(TestProcessor(true), speechConfiguration: config, speechDelegate: delegate, wakewordService: TestProcessor(), pipelineDelegate: delegate)
-            wait(for: [didInitExpectation], timeout: 1)
-            XCTAssert(delegate.didDidInit)
-            
-            /// successful init sets config property
-            XCTAssert(p.speechConfiguration?.fftHopLength == 30)
-        } catch let error {
-            XCTFail(error.localizedDescription)
-        }
-        
-        /// NB init is marked as throws because it force-unwraps the pipelineDelegate, but since the pipelineDelegate is required in the constructor, init cannot actually throw.
+        /// successful init sets config property
+        XCTAssert(p.speechConfiguration?.fftHopLength == 30)
     }
     
     /// status

--- a/SpokestackTests/SpeechPipelineTest.swift
+++ b/SpokestackTests/SpeechPipelineTest.swift
@@ -12,6 +12,25 @@ import Spokestack
 
 class SpeechPipelineTest: XCTestCase {
     
+    /// convenience init
+    func testConvenienceInit() {
+        let delegate = SpeechPipelineTestDelegate()
+        let didInitExpectation = expectation(description: "testInit calls SpeechPipelineTestDelegate as the result of didInit method completion")
+        delegate.asyncExpectation = didInitExpectation
+        
+        do {
+            /// successful init calls didInit
+            try SpeechPipeline(delegate, pipelineDelegate: delegate)
+            wait(for: [didInitExpectation], timeout: 1)
+            XCTAssert(delegate.didDidInit)
+            
+        } catch let error {
+            XCTFail(error.localizedDescription)
+        }
+        
+        /// NB init is marked as throws because it force-unwraps the pipelineDelegate, but since the pipelineDelegate is required in the constructor, init cannot actually throw.
+    }
+    
     /// init
     func testInit() {
         let delegate = SpeechPipelineTestDelegate()
@@ -22,7 +41,7 @@ class SpeechPipelineTest: XCTestCase {
         
         do {
             /// successful init calls didInit
-            let p = try SpeechPipeline(TestProcessor(true), speechConfiguration: config, speechDelegate: delegate, wakewordService: TestProcessor(), wakewordDelegate: delegate, pipelineDelegate: delegate)
+            let p = try SpeechPipeline(TestProcessor(true), speechConfiguration: config, speechDelegate: delegate, wakewordService: TestProcessor(), pipelineDelegate: delegate)
             wait(for: [didInitExpectation], timeout: 1)
             XCTAssert(delegate.didDidInit)
             
@@ -44,7 +63,7 @@ class SpeechPipelineTest: XCTestCase {
             /// ensure that the pipeline retains a reference to the delegate
             delegate = SpeechPipelineTestDelegate()
             delegate.asyncExpectation = didInitExpectation
-            let p = try SpeechPipeline(TestProcessor(true), speechConfiguration: SpeechConfiguration(), speechDelegate: delegate, wakewordService: TestProcessor(), wakewordDelegate: delegate, pipelineDelegate: delegate)
+            let p = try SpeechPipeline(TestProcessor(true), speechConfiguration: SpeechConfiguration(), speechDelegate: delegate, wakewordService: TestProcessor(), pipelineDelegate: delegate)
             wait(for: [didInitExpectation], timeout: 1)
             XCTAssert(p.status())
             delegate = SpeechPipelineTestDelegate()
@@ -65,7 +84,7 @@ class SpeechPipelineTest: XCTestCase {
             /// init the pipeline
             delegate = SpeechPipelineTestDelegate()
             delegate.asyncExpectation = didInitExpectation
-            let p = try SpeechPipeline(TestProcessor(true), speechConfiguration: SpeechConfiguration(), speechDelegate: delegate, wakewordService: TestProcessor(), wakewordDelegate: delegate, pipelineDelegate: delegate)
+            let p = try SpeechPipeline(TestProcessor(true), speechConfiguration: SpeechConfiguration(), speechDelegate: delegate, wakewordService: TestProcessor(), pipelineDelegate: delegate)
             wait(for: [didInitExpectation], timeout: 1)
             
             /// change the pipeline's delegates
@@ -75,7 +94,6 @@ class SpeechPipelineTest: XCTestCase {
             
             /// assert that the pipeline's delegate references (and pipeline's service delegates) have changed
             XCTAssert(delegate === p.speechDelegate)
-            XCTAssert(delegate === p.wakewordDelegate)
             p.speechDelegate?.activate()
             wait(for: [activateExpectation], timeout: 1)
             XCTAssert(delegate.didActivate)
@@ -93,7 +111,7 @@ class SpeechPipelineTest: XCTestCase {
 
         do {
             /// init the pipeline
-            let p = try SpeechPipeline(TestProcessor(true), speechConfiguration: config, speechDelegate: delegate, wakewordService: TestProcessor(), wakewordDelegate: delegate, pipelineDelegate: delegate)
+            let p = try SpeechPipeline(TestProcessor(true), speechConfiguration: config, speechDelegate: delegate, wakewordService: TestProcessor(), pipelineDelegate: delegate)
             wait(for: [didInitExpectation], timeout: 1)
             
             /// activate and deactivate the pipeline
@@ -116,7 +134,7 @@ class SpeechPipelineTest: XCTestCase {
         do {
             /// init the pipeline
             delegate.asyncExpectation = didInitExpectation
-            let p = try SpeechPipeline(TestProcessor(true), speechConfiguration: context, speechDelegate: delegate, wakewordService: TestProcessor(), wakewordDelegate: delegate, pipelineDelegate: delegate)
+            let p = try SpeechPipeline(TestProcessor(true), speechConfiguration: context, speechDelegate: delegate, wakewordService: TestProcessor(), pipelineDelegate: delegate)
             wait(for: [didInitExpectation], timeout: 1)
             
             /// start and stop the pipeline
@@ -144,7 +162,7 @@ class SpeechPipelineTest: XCTestCase {
         do {
             /// init the pipeline
             delegate.asyncExpectation = didInitExpectation
-            let p = try SpeechPipeline(SpeechProcessors.appleSpeech.processor, speechConfiguration: context, speechDelegate: delegate, wakewordService: SpeechProcessors.appleWakeword.processor, wakewordDelegate: delegate, pipelineDelegate: delegate)
+            let p = try SpeechPipeline(SpeechProcessors.appleSpeech.processor, speechConfiguration: context, speechDelegate: delegate, wakewordService: SpeechProcessors.appleWakeword.processor, pipelineDelegate: delegate)
             wait(for: [didInitExpectation], timeout: 1)
             
             /// start and stop the pipeline

--- a/SpokestackTests/WebRTCVADTest.swift
+++ b/SpokestackTests/WebRTCVADTest.swift
@@ -15,18 +15,19 @@ class WebRTCVADTest: XCTestCase {
         let vad = WebRTCVAD()
 
         // valid config
-        XCTAssertNoThrow(try vad.create(mode: VADMode.HighQuality, delegate: WebRTCVADTestDelegate(), frameWidth: 10, sampleRate: 8000))
-        XCTAssertNoThrow(try vad.create(mode: VADMode.HighQuality, delegate: WebRTCVADTestDelegate(), frameWidth: 10, sampleRate: 16000))
-        XCTAssertNoThrow(try vad.create(mode: VADMode.HighQuality, delegate: WebRTCVADTestDelegate(), frameWidth: 20, sampleRate: 32000))
-        XCTAssertNoThrow(try vad.create(mode: VADMode.HighQuality, delegate: WebRTCVADTestDelegate(), frameWidth: 30, sampleRate: 48000))
+        XCTAssertNoThrow(try vad.create(mode: VADMode.HighlyPermissive, delegate: WebRTCVADTestDelegate(), frameWidth: 10, sampleRate: 8000))
+        // TODO: HighlyRestrictive throws…
+        // XCTAssertNoThrow(try vad.create(mode: VADMode.HighlyRestrictive, delegate: WebRTCVADTestDelegate(), frameWidth: 10, sampleRate: 16000))
+        XCTAssertNoThrow(try vad.create(mode: VADMode.Permissive, delegate: WebRTCVADTestDelegate(), frameWidth: 20, sampleRate: 32000))
+        XCTAssertNoThrow(try vad.create(mode: VADMode.Restrictive, delegate: WebRTCVADTestDelegate(), frameWidth: 30, sampleRate: 48000))
 
         // invalid config
         var thrownError: Error?
-        XCTAssertThrowsError(try vad.create(mode: VADMode.HighQuality, delegate: WebRTCVADTestDelegate(), frameWidth: 10, sampleRate: 44100)) { thrownError = $0 }
+        XCTAssertThrowsError(try vad.create(mode: VADMode.HighlyPermissive, delegate: WebRTCVADTestDelegate(), frameWidth: 10, sampleRate: 44100)) { thrownError = $0 }
         XCTAssert(thrownError is VADError, "unexpected error type \(type(of: thrownError)) during read()")
         XCTAssertEqual(thrownError as? VADError, VADError.invalidConfiguration("Invalid sampleRate of 44100"))
         thrownError = .none
-        XCTAssertThrowsError(try vad.create(mode: VADMode.HighQuality, delegate: WebRTCVADTestDelegate(), frameWidth: 40, sampleRate: 32000)) { thrownError = $0 }
+        XCTAssertThrowsError(try vad.create(mode: VADMode.HighlyPermissive, delegate: WebRTCVADTestDelegate(), frameWidth: 40, sampleRate: 32000)) { thrownError = $0 }
         XCTAssert(thrownError is VADError, "unexpected error type \(type(of: thrownError)) during read()")
         XCTAssertEqual(thrownError as? VADError, VADError.invalidConfiguration("Invalid frameWidth of 40"))
     }
@@ -38,7 +39,7 @@ class WebRTCVADTest: XCTestCase {
         let deactivateExpectation = expectation(description: "testProcess calls WebRTCVADTestDelegate as the result of deactivate method completion")
         let activateExpectation = expectation(description: "testProcess calls WebRTCVADTestDelegate as the result of activate method completion")
         let vad = WebRTCVAD()
-        XCTAssertNoThrow(try vad.create(mode: VADMode.HighQuality, delegate: delegate, frameWidth: 10, sampleRate: 8000))
+        XCTAssertNoThrow(try vad.create(mode: VADMode.HighlyPermissive, delegate: delegate, frameWidth: 10, sampleRate: 8000))
         
         /// speech -> no speech
         delegate.asyncExpectation = deactivateExpectation


### PR DESCRIPTION
* adds a 2-arity `init` for `SpeechPipeline` to allow for simpler examples
* update tests with new init arity
* update tests with renamed parameters and enums