### PR TITLE
Fix TextToSpeechInput.inputFormat; SpeechPipeline.setDelegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,15 @@ Activity Detection (VAD), wakeword activation, and Automatic Speech Recognition 
 
 This example creates a speech recognition pipeline using a wakeword detector that is triggered by VAD, which in turn activates an ASR, returning the resulting utterance to the `SpeechEventListener` event listener (`self` in this example).
 
+See `SpeechPipeline` and `SpeechConfiguration` for further configuration documentation.
+
 ### Reference implementation
 
-The `SpokestackFrameworkExample` project contains reference implementations for how to use the Spokestack library, along with runnable examples of the wakeword and ASR components.
+The `SpokestackFrameworkExample` project contains reference implementations for how to use the Spokestack library, along with runnable examples of the wakeword and ASR components. Each component has a corresponding screen from the main screen, and can be started, stopped, or synthesized, as appropriate. The component screens have full debug tracing enabled, so the system control logic and debug events will appear in the XCode Console.
 
-See `SpeechPipeline` and `SpeechConfiguration` for further configuration documentation.
+#### Troubleshooting
+
+A build error similar to `Code Sign error: No unexpired provisioning profiles found that contain any of the keychain's signing certificates` will occur if the bundle identifier is not changed from `io.Spokestack.SpokestackFrameworkExample`, which is tied to the Spokestack organization. 
 
 ## API Reference
 

--- a/Spokestack/SpeechPipeline.swift
+++ b/Spokestack/SpeechPipeline.swift
@@ -127,10 +127,12 @@ import Foundation
     
     /// Sets the property for the`SpeechEventListener` delegate .
     /// - Parameter speechDelegate: a `SpeechEventListener` protocol implementer.
-    @objc public func setDelegates(_ speechDelegate: SpeechEventListener) -> Void {
+    @objc public func setDelegates(_ speechDelegate: SpeechEventListener, pipelineDelegate: PipelineDelegate) -> Void {
         self.speechDelegate = speechDelegate
         self.speechRecognizerService.delegate = self.speechDelegate
         self.wakewordRecognizerService.delegate = self.speechDelegate
+        self.pipelineDelegate = pipelineDelegate
+        AudioController.sharedInstance.pipelineDelegate = self.pipelineDelegate
     }
     
     /// MARK: Pipeline control

--- a/Spokestack/TextToSpeech.swift
+++ b/Spokestack/TextToSpeech.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-@objc public enum TTSInputType: Int {
+@objc public enum TTSInputFormat: Int {
     case text
     case ssml
 }
@@ -42,8 +42,17 @@ import Foundation
         request.addValue(self.configuration.authorization, forHTTPHeaderField: "Authorization")
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpMethod = "POST"
+        var inputFormat: String
+        switch input.inputFormat {
+        case .text:
+            inputFormat = "text"
+            break
+        case .ssml:
+            inputFormat = "ssml"
+            break
+        }
         let body = ["voice": input.voice,
-                    "text": input.input]
+                    inputFormat: input.input]
         request.httpBody =  try? JSONSerialization.data(withJSONObject: body, options: [])
         Trace.trace(Trace.Level.DEBUG, configLevel: self.configuration.tracing, message: "request \(request.debugDescription) \(String(describing: request.allHTTPHeaderFields)) \(String(data: request.httpBody!, encoding: String.Encoding.ascii) ?? "no body")", delegate: self.delegate, caller: self)
         

--- a/Spokestack/TextToSpeechInput.swift
+++ b/Spokestack/TextToSpeechInput.swift
@@ -23,6 +23,15 @@ import Foundation
         self.input = input
         super.init()
     }
+
+    /// Convenience initializer for a new TextToSpeechInput instance.
+    /// - Parameter input: The text input to the speech synthesizer.
+    /// - Parameter voice: The synthetic voice used to generate speech.
+    /// - Parameter inputFormat: The formatting of the input.
+    @objc public init(_ input:String, inputFormat: TTSInputFormat) {
+        self.input = input
+        self.inputFormat = inputFormat
+    }
     
     /// Convenience initializer for a new TextToSpeechInput instance.
     /// - Parameter input: The text input to the speech synthesizer.

--- a/Spokestack/TextToSpeechInput.swift
+++ b/Spokestack/TextToSpeechInput.swift
@@ -28,7 +28,7 @@ import Foundation
     /// - Parameter input: The text input to the speech synthesizer.
     /// - Parameter voice: The synthetic voice used to generate speech.
     /// - Parameter inputFormat: The formatting of the input.
-    @objc public init(_ input:String, voice: String, inputFormat: TTSInputType) {
+    @objc public init(_ input:String, voice: String, inputFormat: TTSInputFormat) {
         self.input = input
         self.voice = voice
         self.inputFormat = inputFormat
@@ -40,5 +40,5 @@ import Foundation
     /// - Note: SSML should be unescaped.
     @objc public var input: String = "Here I am, a brain the size of a planet."
     /// The formatting of the input.
-    @objc public var inputFormat: TTSInputType = .text
+    @objc public var inputFormat: TTSInputFormat = .text
 }

--- a/SpokestackTests/SpeechPipelineTest.swift
+++ b/SpokestackTests/SpeechPipelineTest.swift
@@ -72,7 +72,7 @@ class SpeechPipelineTest: XCTestCase {
         /// change the pipeline's delegates
         delegate = SpeechPipelineTestDelegate()
         delegate.asyncExpectation = activateExpectation
-        p.setDelegates(delegate)
+        p.setDelegates(delegate, pipelineDelegate: delegate)
         
         /// assert that the pipeline's delegate references (and pipeline's service delegates) have changed
         XCTAssert(delegate === p.speechDelegate)

--- a/SpokestackTests/TextToSpeechTest.swift
+++ b/SpokestackTests/TextToSpeechTest.swift
@@ -40,6 +40,15 @@ class TextToSpeechTest: XCTestCase {
         XCTAssert(delegate.didSucceed)
         XCTAssertFalse(delegate.didFail)
         
+        delegate.reset()
+        let didSucceedExpectation2 = expectation(description: "successful request calls TestTTSGenerationDelegate.success")
+        delegate.asyncExpectation = didSucceedExpectation2
+        let ssmlInput = TextToSpeechInput("<speak>Yet right now the average age of this 52nd Parliament is 49 years old, <break time='500ms'/> OK Boomer.</speak>", voice: "demo-male", inputFormat: .ssml)
+        tts.synthesize(ssmlInput)
+        wait(for: [didSucceedExpectation2], timeout: 5)
+        XCTAssert(delegate.didSucceed)
+        XCTAssertFalse(delegate.didFail)
+        
         // bad input results in a failed request that calls failure
         delegate.reset()
         let didFailInputExpectation = expectation(description: "bad input results in a failed request that calls TestTTSGenerationDelegate.failure")


### PR DESCRIPTION
Both of these are currently crippled due to authorial oversight. This fixes them.