### PR TITLE
TextToSpeech.speak API

### DIFF
--- a/Spokestack/SpeechPipeline.swift
+++ b/Spokestack/SpeechPipeline.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /**
- This is the primary client entry point to the SpokeStack framework. It dynamically binds to configured components that implement the pipeline interfaces for reading audio frames and performing speech recognition tasks.
+ This is the primary client entry point to the Spokestack voice input system. It dynamically binds to configured components that implement the pipeline interfaces for reading audio frames and performing speech recognition tasks.
 
  The pipeline may be stopped/restarted any number of times during its lifecycle. While stopped, the pipeline consumes as few resources as possible. The pipeline runs asynchronously on a dedicated thread, so it does not block the caller when performing I/O and speech processing.
 

--- a/Spokestack/TextToSpeech.swift
+++ b/Spokestack/TextToSpeech.swift
@@ -15,12 +15,28 @@ import AVFoundation
 }
 
 
-/// <#Description#>
+/**
+ This is the client entry point for the Spokestack Text to Speech (TTS) system. It provides the capability to synthesize textual input, and speak back the synthesis as audio system output. The synthesis and speech occur on asynchronous blocks so as to not block the client while it performs network and audio system activities.
+ 
+ When inititalized,  the TTS system communicates with the client via delegates that receive events.
+ 
+ ```
+ // assume that self implements the TextToSpeechDelegate protocol.
+ let configuration = SpeechConfiguration()
+ let tts = TextToSpeech(self, configuration: configuration)
+ let input = TextToSpeechInput()
+ input.text = "Hello world!"
+ tts.synthesize(input) // synthesize the provided default text input using the default synthetic voice and api key.
+ tts.speak(input) // synthesize the same input as above, and play back the result using the default audio system.
+ ```
+ */
 @objc public class TextToSpeech: NSObject {
     
     // MARK: Properties
     
+    /// Delegate that receives TTS events.
     weak public var delegate: TextToSpeechDelegate?
+    
     private var configuration: SpeechConfiguration
     private lazy var player: AVPlayer = AVPlayer()
     
@@ -41,6 +57,10 @@ import AVFoundation
     
     // MARK: Public Functions
     
+    /// Synthesize speech using the provided input parameters and speech configuration, and play back the result using the default audio system.
+    /// - Parameter input:  Parameters that specify the speech to synthesize.
+    /// - Note: Playback will begin immediately after  the synthesis results are received and buffered. Uses `AVPlayer` for playback.
+    /// - Warning: `AVAudioSession.Category` and `AVAudioSession.CategoryOptions` must be set by the client to compatible settings that allow for playback through the desired audio sytem ouputs. For performance reasons, this is only verified upon class initialization and not when calling this function.
     @objc public func speak(_ input: TextToSpeechInput) -> Void {
         func play(url: URL) {
             DispatchQueue.main.async {
@@ -123,12 +143,19 @@ import AVFoundation
         self.delegate?.success(url: url)
     }
     
-    @objc func playerDidFinishPlaying(sender: Notification) {
+    /// Internal function that must be public for Objective-C compatibility reasons.
+    /// - Warning: Client should never call this function.
+    @available(*, deprecated, message: "Internal function that must be public for Objective-C compatibility reasons. Client should never call this function.")
+    @objc
+    func playerDidFinishPlaying(sender: Notification) {
         print("player didFinishSpeaking")
         self.delegate?.didFinishSpeaking()
         NotificationCenter.default.removeObserver(self, name: .AVPlayerItemDidPlayToEndTime, object: self.player.currentItem)
     }
     
+    /// Internal function that must be public for Objective-C compatibility reasons.
+    /// - Warning: Client should never call this function.
+    @available(*, deprecated, message: "Internal function that must be public for Objective-C compatibility reasons. Client should never call this function.")
     override public func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         DispatchQueue.main.async {
             switch keyPath {

--- a/Spokestack/TextToSpeech.swift
+++ b/Spokestack/TextToSpeech.swift
@@ -59,7 +59,7 @@ import AVFoundation
     
     /// Synthesize speech using the provided input parameters and speech configuration, and play back the result using the default audio system.
     /// - Parameter input:  Parameters that specify the speech to synthesize.
-    /// - Note: Playback will begin immediately after  the synthesis results are received and buffered. Uses `AVPlayer` for playback.
+    /// - Note: Playback will begin immediately after the synthesis results are received and buffered. Uses `AVPlayer` for playback.
     /// - Warning: `AVAudioSession.Category` and `AVAudioSession.CategoryOptions` must be set by the client to compatible settings that allow for playback through the desired audio sytem ouputs. For performance reasons, this is only verified upon class initialization and not when calling this function.
     @objc public func speak(_ input: TextToSpeechInput) -> Void {
         func play(url: URL) {
@@ -148,7 +148,6 @@ import AVFoundation
     @available(*, deprecated, message: "Internal function that must be public for Objective-C compatibility reasons. Client should never call this function.")
     @objc
     func playerDidFinishPlaying(sender: Notification) {
-        print("player didFinishSpeaking")
         self.delegate?.didFinishSpeaking()
         NotificationCenter.default.removeObserver(self, name: .AVPlayerItemDidPlayToEndTime, object: self.player.currentItem)
     }

--- a/Spokestack/TextToSpeech.swift
+++ b/Spokestack/TextToSpeech.swift
@@ -58,9 +58,13 @@ import AVFoundation
     // MARK: Public Functions
     
     /// Synthesize speech using the provided input parameters and speech configuration, and play back the result using the default audio system.
+    ///
+    /// Playback is provided as a convenience for the client. The client is responsible for coordinating the audio system resources and utilization required by `SpeechPipeline` and/or other media playback. The `TextToSpeechDelegate.didBeginSpeaking` and `TextToSpeechDelegate.didFinishSpeaking` callbacks may be utilized for this purpose.
+    ///
+    /// The `TextToSpeech` class handles all memory management for the playback components it utilizes.
     /// - Parameter input:  Parameters that specify the speech to synthesize.
-    /// - Note: Playback will begin immediately after the synthesis results are received and buffered. Uses `AVPlayer` for playback.
-    /// - Warning: `AVAudioSession.Category` and `AVAudioSession.CategoryOptions` must be set by the client to compatible settings that allow for playback through the desired audio sytem ouputs. For performance reasons, this is only verified upon class initialization and not when calling this function.
+    /// - Note: Playback will begin immediately after the synthesis results are received and sufficiently buffered.
+    /// - Warning: `AVAudioSession.Category` and `AVAudioSession.CategoryOptions` must be set by the client to compatible settings that allow for playback through the desired audio sytem ouputs.
     @objc public func speak(_ input: TextToSpeechInput) -> Void {
         func play(url: URL) {
             DispatchQueue.main.async {

--- a/Spokestack/TextToSpeechDelegate.swift
+++ b/Spokestack/TextToSpeechDelegate.swift
@@ -11,19 +11,22 @@ import Foundation
 /// Protocol for receiving the response of a TTS request
 @objc public protocol TextToSpeechDelegate: AnyObject {
     
-    /// The TTS request has resulted in a successful response.
+    /// The TTS synthesis request has resulted in a successful response.
     /// - Note: The URL will be invalidated within 60 seconds of generation.
     /// - Parameter url: The url pointing to the TTS media container
     func success(url: URL) -> Void
     
-    /// The TTS request has resulted in an error response.
+    /// The TTS synthesis request has resulted in an error response.
     /// - Parameter error: The error representing the TTS response.
     func failure(error: Error) -> Void
+    
+    /// The TTS synthesis request has begun playback over the default audio system.
+    func didBeginSpeaking() -> Void
+    
+    /// The TTS synthesis request has finished playback.
+    func didFinishSpeaking() -> Void
     
     /// A trace event from the TTS system.
     /// - Parameter trace: The debugging trace message.
     func didTrace(_ trace: String) -> Void
-    
-    func didBeginSpeaking() -> Void
-    func didFinishSpeaking() -> Void
 }

--- a/Spokestack/TextToSpeechDelegate.swift
+++ b/Spokestack/TextToSpeechDelegate.swift
@@ -23,4 +23,7 @@ import Foundation
     /// A trace event from the TTS system.
     /// - Parameter trace: The debugging trace message.
     func didTrace(_ trace: String) -> Void
+    
+    func didBeginSpeaking() -> Void
+    func didFinishSpeaking() -> Void
 }

--- a/SpokestackFrameworkExample/TTSViewController.swift
+++ b/SpokestackFrameworkExample/TTSViewController.swift
@@ -44,6 +44,22 @@ class TTSViewController: UIViewController {
         return button
     }()
     
+    lazy var speakButton: UIButton = {
+        
+        let button: UIButton = UIButton(frame: .zero)
+        
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("Speak", for: .normal)
+        button.addTarget(self,
+                         action: #selector(TTSViewController.speakAction(_:)),
+                         for: .touchUpInside)
+        
+        button.setTitleColor(.purple, for: .normal)
+        
+        
+        return button
+    }()
+
     lazy var testButton: UIButton = {
         
         let button: UIButton = UIButton(frame: .zero)
@@ -102,6 +118,7 @@ class TTSViewController: UIViewController {
         
         self.view.addSubview(self.synthesizeButton)
         self.view.addSubview(self.playButton)
+        self.view.addSubview(self.speakButton)
         self.view.addSubview(self.testButton)
         
         self.synthesizeButton.centerYAnchor.constraint(equalTo: self.view.centerYAnchor).isActive = true
@@ -111,16 +128,20 @@ class TTSViewController: UIViewController {
         self.playButton.topAnchor.constraint(equalTo: self.synthesizeButton.bottomAnchor, constant: 50.0).isActive = true
         self.playButton.leftAnchor.constraint(equalTo: self.synthesizeButton.leftAnchor).isActive = true
         self.playButton.rightAnchor.constraint(equalTo: self.synthesizeButton.rightAnchor).isActive = true
+
+        self.speakButton.topAnchor.constraint(equalTo: self.playButton.bottomAnchor, constant: 50.0).isActive = true
+        self.speakButton.leftAnchor.constraint(equalTo: self.playButton.leftAnchor).isActive = true
+        self.speakButton.rightAnchor.constraint(equalTo: self.playButton.rightAnchor).isActive = true
         
-        self.testButton.topAnchor.constraint(equalTo: self.playButton.bottomAnchor, constant: 50.0).isActive = true
-        self.testButton.leftAnchor.constraint(equalTo: self.playButton.leftAnchor).isActive = true
-        self.testButton.rightAnchor.constraint(equalTo: self.playButton.rightAnchor).isActive = true
+        self.testButton.topAnchor.constraint(equalTo: self.speakButton.bottomAnchor, constant: 50.0).isActive = true
+        self.testButton.leftAnchor.constraint(equalTo: self.speakButton.leftAnchor).isActive = true
+        self.testButton.rightAnchor.constraint(equalTo: self.speakButton.rightAnchor).isActive = true
         
         self.view.addSubview(ttsInput)
         
         self.player.automaticallyWaitsToMinimizeStalling = false
         
-        self.configuration.tracing = .DEBUG
+        self.configuration.tracing = .PERF
         
         self.tts = TextToSpeech(self, configuration: configuration)
     }
@@ -147,6 +168,14 @@ class TTSViewController: UIViewController {
         let playerItem = AVPlayerItem(url: streamingFile)
         self.player = AVPlayer(playerItem: playerItem)
         self.player.play()
+    }
+    
+    @objc func speakAction(_ sender: Any) {
+        print("speak")
+        var text = self.ttsInput.text ?? ""
+        if (text == "") { text = "You didn't enter any text to synthesize." }
+        let input = TextToSpeechInput(text)
+        self.tts?.speak(input)
     }
     
     @objc func testAction(_ sender: Any) {
@@ -195,7 +224,6 @@ extension TTSViewController {
         TICK() // play timer
         DispatchQueue.main.async {
             self.playerItem = AVPlayerItem(url: self.streamingFile!) //URL(string: "http://devimages.apple.com/iphone/samples/bipbop/bipbopall.m3u8")!)
-            NotificationCenter.default.removeObserver(self, name: .AVPlayerItemDidPlayToEndTime, object: self.player.currentItem)
             self.playerItem!.addObserver(self, forKeyPath: #keyPath(AVPlayerItem.duration), options: [.old, .new], context: nil)
             self.playerItem!.addObserver(self, forKeyPath: #keyPath(AVPlayerItem.status), options: [.old, .new], context: nil)
             self.playerItem!.addObserver(self, forKeyPath: #keyPath(AVPlayerItem.isPlaybackBufferEmpty), options: [.old, .new], context: nil)
@@ -250,6 +278,14 @@ extension TTSViewController {
 // MARK: TextToSpeechDelegate implementation
 
 extension TTSViewController: TextToSpeechDelegate {
+    func didBeginSpeaking() {
+        print("didBeginSpeaking")
+    }
+    
+    func didFinishSpeaking() {
+        print("didFinishSpeaking")
+    }
+    
     func success(url: URL) {
         TOCK() // synthesize timer
         print(url)


### PR DESCRIPTION
Adds a new `speak` function to the existing TTS API. The `speak` function takes the same input as the `synthesize` function, but in addition to synthesizing the input, it also plays the result immediately after receiving the synthesis result using the default Apple audio player.