### PR TITLE
Revised TTS API

### DIFF
--- a/Spokestack.xcodeproj/project.pbxproj
+++ b/Spokestack.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		01D31F8B216BB0220055FD45 /* Results.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D31F89216BB0220055FD45 /* Results.swift */; };
 		01D31F8E216BB0370055FD45 /* Typealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D31F8D216BB0370055FD45 /* Typealiases.swift */; };
 		01D31F8F216BB0370055FD45 /* Typealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D31F8D216BB0370055FD45 /* Typealiases.swift */; };
+		5912341C23AD675500BBAA3A /* TextToSpeechResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5912341B23AD675500BBAA3A /* TextToSpeechResult.swift */; };
 		592C0B7B2385B5E800308CCD /* TTSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592C0B7A2385B5E800308CCD /* TTSViewController.swift */; };
 		5936077D236B687C00FFA29F /* Detect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C15D55234E42F800B091F4 /* Detect.swift */; };
 		5936077E236B687F00FFA29F /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C15D54234E42F700B091F4 /* Filter.swift */; };
@@ -159,6 +160,7 @@
 		59062F0C22A5AA9D00613AD8 /* WITVad.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WITVad.m; sourceTree = "<group>"; };
 		59062F0D22A5AA9E00613AD8 /* WITCvad.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WITCvad.m; sourceTree = "<group>"; };
 		59062F0F22A5AA9E00613AD8 /* WITCvad.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WITCvad.h; sourceTree = "<group>"; };
+		5912341B23AD675500BBAA3A /* TextToSpeechResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TextToSpeechResult.swift; path = "../../spokestack-ios/Spokestack/TextToSpeechResult.swift"; sourceTree = "<group>"; };
 		592C0B7A2385B5E800308CCD /* TTSViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TTSViewController.swift; path = "../../spokestack-ios/SpokestackFrameworkExample/TTSViewController.swift"; sourceTree = "<group>"; };
 		592D2651233C18D700354AF8 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		59365947220889EE00C0365F /* AppleWakewordRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleWakewordRecognizer.swift; sourceTree = "<group>"; };
@@ -358,6 +360,7 @@
 				59A0D5C52204E8E4003709C3 /* SpeechConfiguration.swift */,
 				59E0E1362301F0A80060F012 /* Trace.swift */,
 				596567802384AA1100CFCE23 /* TextToSpeechInput.swift */,
+				5912341B23AD675500BBAA3A /* TextToSpeechResult.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -703,6 +706,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				59365948220889EE00C0365F /* AppleWakewordRecognizer.swift in Sources */,
+				5912341C23AD675500BBAA3A /* TextToSpeechResult.swift in Sources */,
 				5942C4352384764900EC0B13 /* TextToSpeechDelegate.swift in Sources */,
 				59FB0C8822A98E1900FB9662 /* CoreMLWakewordRecognizer.swift in Sources */,
 				596B82482384A097004BAEF4 /* TextToSpeech.swift in Sources */,
@@ -830,6 +834,7 @@
 				DEVELOPMENT_TEAM = S55ZL97588;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = SpokestackFrameworkExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -854,6 +859,7 @@
 				DEVELOPMENT_TEAM = S55ZL97588;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = SpokestackFrameworkExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1014,6 +1020,7 @@
 				);
 				INFOPLIST_FILE = Spokestack/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1057,6 +1064,7 @@
 				);
 				INFOPLIST_FILE = Spokestack/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Spokestack.xcodeproj/project.pbxproj
+++ b/Spokestack.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		596567812384AA1100CFCE23 /* TextToSpeechInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596567802384AA1100CFCE23 /* TextToSpeechInput.swift */; };
 		5967108E21F7AE6B00CBFC88 /* AppleSpeechRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5967108D21F7AE6B00CBFC88 /* AppleSpeechRecognizer.swift */; };
 		596B82482384A097004BAEF4 /* TextToSpeech.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596B82472384A097004BAEF4 /* TextToSpeech.swift */; };
+		5989319723BE8C8800310589 /* TextToSpeechResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5912341B23AD675500BBAA3A /* TextToSpeechResult.swift */; };
 		59A0D5C02204E786003709C3 /* AppleASRViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A0D5BD2204E786003709C3 /* AppleASRViewController.swift */; };
 		59A0D5C22204E786003709C3 /* AppleWakewordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A0D5BF2204E786003709C3 /* AppleWakewordViewController.swift */; };
 		59A0D5C42204E799003709C3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 59A0D5C32204E799003709C3 /* Assets.xcassets */; };
@@ -757,6 +758,7 @@
 				59A8DBFA2384AC0100F97700 /* TextToSpeech.swift in Sources */,
 				59C2AFDF2319CE8000E47AC5 /* SpeechProcessor.swift in Sources */,
 				5936077F236B688400FFA29F /* WebRTCVAD.swift in Sources */,
+				5989319723BE8C8800310589 /* TextToSpeechResult.swift in Sources */,
 				59D78F5F2322D13700728A98 /* AudioControllerTest.swift in Sources */,
 				5942C4362384772600EC0B13 /* TextToSpeechDelegate.swift in Sources */,
 				59A8DBF92384ABF000F97700 /* TextToSpeechTest.swift in Sources */,

--- a/Spokestack/Error.swift
+++ b/Spokestack/Error.swift
@@ -56,4 +56,8 @@ enum RingBufferStateError: Error {
 enum TextToSpeechErrors: Error {
     /// The synthesize response was missing data.
     case deserialization(String)
+    /// The synthesize request was unable to be serialized.
+    case serialization(String)
+    /// The api key provided is not valid.
+    case apiKey(String)
 }

--- a/Spokestack/Error.swift
+++ b/Spokestack/Error.swift
@@ -60,4 +60,6 @@ enum TextToSpeechErrors: Error {
     case serialization(String)
     /// The api key provided is not valid.
     case apiKey(String)
+    /// The speak command could not be executed.
+    case speak(String)
 }

--- a/Spokestack/SpeechConfiguration.swift
+++ b/Spokestack/SpeechConfiguration.swift
@@ -108,7 +108,12 @@ import Foundation
     /// - SeeAlso: `CoreMLWakewordRecognizer`, `TFLiteWakewordRecognizer`
     @objc public var detectModelPath: String = "Detect.lite"
     /// Text To Speech API authorization key
+    @available(*, deprecated, message: "Authorization key is no longer supported for Text To Speech service, use apiId + apiKey instead.")
     @objc public var authorization: String = "Key f854fbf30a5f40c189ecb1b38bc78059"
+    /// Text To Speech API client identifier.
+    @objc public var apiId: String = "f0bc990c-e9db-4a0c-a2b1-6a6395a3d97e"
+    /// Text To Speech API client secret key
+    @objc public var apiKey: String = "5BD5483F573D691A15CFA493C1782F451D4BD666E39A9E7B2EBE287E6A72C6B6"
     /// Debugging trace levels, for simple filtering.
     @objc public var tracing: Trace.Level = Trace.Level.NONE
 }

--- a/Spokestack/TextToSpeech.swift
+++ b/Spokestack/TextToSpeech.swift
@@ -104,7 +104,7 @@ import CryptoKit
         switch inputFormat {
         case .ssml:
             body = [
-                "query":"query synthesis($voice: String!, $ssml: String!) {synthesizeSsml(voice: $voice, ssml: $ssml) {url}}",
+                "query":"query iOSSynthesisSSML($voice: String!, $ssml: String!) {synthesizeSsml(voice: $voice, ssml: $ssml) {url}}",
                 "variables":[
                     "voice":self.ttsInputVoices[input.voice.rawValue],
                     "ssml":input.input
@@ -113,7 +113,7 @@ import CryptoKit
             break
         case .text:
             body = [
-                "query":"query synthesis($voice: String!, $text: String!) {synthesizeText(voice: $voice, text: $text) {url}}",
+                "query":"query iOSSynthesisText($voice: String!, $text: String!) {synthesizeText(voice: $voice, text: $text) {url}}",
                 "variables":[
                     "voice":self.ttsInputVoices[input.voice.rawValue],
                     "text":input.input

--- a/Spokestack/TextToSpeechDelegate.swift
+++ b/Spokestack/TextToSpeechDelegate.swift
@@ -14,7 +14,7 @@ import Foundation
     /// The TTS synthesis request has resulted in a successful response.
     /// - Note: The URL will be invalidated within 60 seconds of generation.
     /// - Parameter url: The url pointing to the TTS media container
-    func success(url: URL) -> Void
+    func success(result: TextToSpeechResult) -> Void
     
     /// The TTS synthesis request has resulted in an error response.
     /// - Parameter error: The error representing the TTS response.

--- a/Spokestack/TextToSpeechInput.swift
+++ b/Spokestack/TextToSpeechInput.swift
@@ -31,7 +31,7 @@ import Foundation
     /// - Parameter voice: The synthetic voice used to generate speech.
     /// - Parameter inputFormat: The formatting of the input.
     /// - Parameter id: A unique identifier for this input request.
-    @objc public init(_ input:String,
+    @objc public init(_ input:String = "<speak>Here I am, a brain the size of a planet.</speak>",
                       voice: TTSInputVoice = .demoMale,
                       inputFormat: TTSInputFormat = .ssml,
                       id: String = UUID().description) {
@@ -39,13 +39,14 @@ import Foundation
         self.voice = voice
         self.inputFormat = inputFormat
         self.id = id
+        super.init()
     }
     
     /// The synthetic voice used to generate speech.
     @objc public var voice: TTSInputVoice = .demoMale
     /// The input to the synthetic voice.
     /// - Note: SSML should be unescaped.
-    @objc public var input: String = "Here I am, a brain the size of a planet."
+    @objc public var input: String = "<speak>Here I am, a brain the size of a planet.</speak>"
     /// The formatting of the input.
     @objc public var inputFormat: TTSInputFormat = .ssml
     /// A unique identifier for this input request.

--- a/Spokestack/TextToSpeechInput.swift
+++ b/Spokestack/TextToSpeechInput.swift
@@ -42,12 +42,12 @@ import Foundation
     }
     
     /// The synthetic voice used to generate speech.
-    @objc public var voice: TTSInputVoice = .demoMale
+    @objc public var voice: TTSInputVoice
     /// The input to the synthetic voice.
     /// - Note: SSML must be valid XML.
-    @objc public var input: String = "Here I am, a brain the size of a planet."
+    @objc public var input: String
     /// The formatting of the input.
-    @objc public var inputFormat: TTSInputFormat = .text
+    @objc public var inputFormat: TTSInputFormat
     /// A unique identifier for this input request.
-    @objc public var id: String = UUID().description
+    @objc public var id: String
 }

--- a/Spokestack/TextToSpeechInput.swift
+++ b/Spokestack/TextToSpeechInput.swift
@@ -8,46 +8,46 @@
 
 import Foundation
 
+/// Designate the format the input is provided in.
+@objc public enum TTSInputFormat: Int {
+    @available(*, unavailable, message: "Text-only input is not currently supported. Encase your text with <speak>text</speak> for SSML compatibility.")
+    /// Plain text
+    case text
+    /// Speech Synthesis Markup Language
+    /// see https://spokestack.io/docs/Concepts/tts for the supported SSML subset.
+    case ssml
+}
+
+@objc public enum TTSInputVoice: Int {
+    case demoMale
+}
+
 /// Input parameters for speech synthesis. Parameters are considered transient and may change each time `synthesize` is called.
 /// - SeeAlso: `TextToSpeech.synthesize`
 @objc public class TextToSpeechInput: NSObject {
     
     /// Initializer for a new TextToSpeechInput instance.
-    @objc public override init() {
-        super.init()
-    }
-    
-    /// Convenience initializer for a new TextToSpeechInput instance.
-    /// - Parameter input: The text input to the speech synthesizer.
-    @objc public init(_ input: String) {
-        self.input = input
-        super.init()
-    }
-
-    /// Convenience initializer for a new TextToSpeechInput instance.
     /// - Parameter input: The text input to the speech synthesizer.
     /// - Parameter voice: The synthetic voice used to generate speech.
     /// - Parameter inputFormat: The formatting of the input.
-    @objc public init(_ input:String, inputFormat: TTSInputFormat) {
-        self.input = input
-        self.inputFormat = inputFormat
-    }
-    
-    /// Convenience initializer for a new TextToSpeechInput instance.
-    /// - Parameter input: The text input to the speech synthesizer.
-    /// - Parameter voice: The synthetic voice used to generate speech.
-    /// - Parameter inputFormat: The formatting of the input.
-    @objc public init(_ input:String, voice: String, inputFormat: TTSInputFormat) {
+    /// - Parameter id: A unique identifier for this input request.
+    @objc public init(_ input:String,
+                      voice: TTSInputVoice = .demoMale,
+                      inputFormat: TTSInputFormat = .ssml,
+                      id: String = UUID().description) {
         self.input = input
         self.voice = voice
         self.inputFormat = inputFormat
+        self.id = id
     }
     
     /// The synthetic voice used to generate speech.
-    @objc public var voice: String = "demo-male"
+    @objc public var voice: TTSInputVoice = .demoMale
     /// The input to the synthetic voice.
     /// - Note: SSML should be unescaped.
     @objc public var input: String = "Here I am, a brain the size of a planet."
     /// The formatting of the input.
-    @objc public var inputFormat: TTSInputFormat = .text
+    @objc public var inputFormat: TTSInputFormat = .ssml
+    /// A unique identifier for this input request.
+    @objc public var id: String = UUID().description
 }

--- a/Spokestack/TextToSpeechInput.swift
+++ b/Spokestack/TextToSpeechInput.swift
@@ -10,7 +10,6 @@ import Foundation
 
 /// Designate the format the input is provided in.
 @objc public enum TTSInputFormat: Int {
-    @available(*, unavailable, message: "Text-only input is not currently supported. Encase your text with <speak>text</speak> for SSML compatibility.")
     /// Plain text
     case text
     /// Speech Synthesis Markup Language
@@ -31,9 +30,9 @@ import Foundation
     /// - Parameter voice: The synthetic voice used to generate speech.
     /// - Parameter inputFormat: The formatting of the input.
     /// - Parameter id: A unique identifier for this input request.
-    @objc public init(_ input:String = "<speak>Here I am, a brain the size of a planet.</speak>",
+    @objc public init(_ input:String = "Here I am, a brain the size of a planet.",
                       voice: TTSInputVoice = .demoMale,
-                      inputFormat: TTSInputFormat = .ssml,
+                      inputFormat: TTSInputFormat = .text,
                       id: String = UUID().description) {
         self.input = input
         self.voice = voice
@@ -45,10 +44,10 @@ import Foundation
     /// The synthetic voice used to generate speech.
     @objc public var voice: TTSInputVoice = .demoMale
     /// The input to the synthetic voice.
-    /// - Note: SSML should be unescaped.
-    @objc public var input: String = "<speak>Here I am, a brain the size of a planet.</speak>"
+    /// - Note: SSML must be valid XML.
+    @objc public var input: String = "Here I am, a brain the size of a planet."
     /// The formatting of the input.
-    @objc public var inputFormat: TTSInputFormat = .ssml
+    @objc public var inputFormat: TTSInputFormat = .text
     /// A unique identifier for this input request.
     @objc public var id: String = UUID().description
 }

--- a/Spokestack/TextToSpeechResult.swift
+++ b/Spokestack/TextToSpeechResult.swift
@@ -9,7 +9,12 @@
 import Foundation
 
 /// Result of the `TextToSpeech.synthesize` request.
-@objc public class TextToSpeechResult: NSObject {
-    @objc public var url: URL = URL(string: "https://spokestack.io")!
-    @objc public var id: String = ""
+public class TextToSpeechResult: NSObject {
+    public var url: URL?
+    public var id: String?
+    
+    public init (id: String, url: URL) {
+        self.id = id
+        self.url = url
+    }
 }

--- a/Spokestack/TextToSpeechResult.swift
+++ b/Spokestack/TextToSpeechResult.swift
@@ -1,0 +1,15 @@
+//
+//  TextToSpeechResult.swift
+//  Spokestack
+//
+//  Created by Noel Weichbrodt on 12/20/19.
+//  Copyright © 2019 Pylon AI, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Result of the `TextToSpeech.synthesize` request.
+@objc public class TextToSpeechResult: NSObject {
+    @objc public var url: URL = URL(string: "https://spokestack.io")!
+    @objc public var id: String = ""
+}

--- a/Spokestack/TextToSpeechResult.swift
+++ b/Spokestack/TextToSpeechResult.swift
@@ -9,12 +9,13 @@
 import Foundation
 
 /// Result of the `TextToSpeech.synthesize` request.
-public class TextToSpeechResult: NSObject {
-    public var url: URL?
-    public var id: String?
+@objc public class TextToSpeechResult: NSObject {
+    @objc public var url: URL?
+    @objc public var id: String?
     
-    public init (id: String, url: URL) {
+    @objc public init (id: String, url: URL) {
         self.id = id
         self.url = url
+        super.init()
     }
 }

--- a/SpokestackFrameworkExample/TTSViewController.swift
+++ b/SpokestackFrameworkExample/TTSViewController.swift
@@ -157,6 +157,7 @@ class TTSViewController: UIViewController {
         var text = self.ttsInput.text ?? ""
         if (text == "") { text = "You didn't enter any text to synthesize." }
         let input = TextToSpeechInput("<speak>\(text)</speak>")
+        input.inputFormat = .ssml
         self.tts?.synthesize(input)
     }
     
@@ -200,7 +201,6 @@ extension TTSViewController {
             print("\(function) Time: \(CACurrentMediaTime()-startTime)\nLine:\(line) File: \(file)")
         }
     }
-    
     
     /**
      Initiates a test run with internal timing and status marks for measuring the request/response and playback of a HTTP2 chunked streaming audio file.

--- a/SpokestackFrameworkExample/TTSViewController.swift
+++ b/SpokestackFrameworkExample/TTSViewController.swift
@@ -141,7 +141,7 @@ class TTSViewController: UIViewController {
         
         self.player.automaticallyWaitsToMinimizeStalling = false
         
-        self.configuration.tracing = .PERF
+        self.configuration.tracing = .DEBUG
         
         self.tts = TextToSpeech(self, configuration: configuration)
     }
@@ -156,7 +156,7 @@ class TTSViewController: UIViewController {
         print("synthesize")
         var text = self.ttsInput.text ?? ""
         if (text == "") { text = "You didn't enter any text to synthesize." }
-        let input = TextToSpeechInput(text)
+        let input = TextToSpeechInput("<speak>\(text)</speak>")
         self.tts?.synthesize(input)
     }
     
@@ -278,6 +278,7 @@ extension TTSViewController {
 // MARK: TextToSpeechDelegate implementation
 
 extension TTSViewController: TextToSpeechDelegate {
+    
     func didBeginSpeaking() {
         print("didBeginSpeaking")
     }
@@ -286,10 +287,10 @@ extension TTSViewController: TextToSpeechDelegate {
         print("didFinishSpeaking")
     }
     
-    func success(url: URL) {
+    func success(result: TextToSpeechResult) {
         TOCK() // synthesize timer
-        print(url)
-        self.streamingFile = url
+        print(result)
+        self.streamingFile = result.url
         if (self.amTesting) {
             self.playTest()
             //self.download(url)

--- a/SpokestackFrameworkExample/TTSViewController.swift
+++ b/SpokestackFrameworkExample/TTSViewController.swift
@@ -289,8 +289,10 @@ extension TTSViewController: TextToSpeechDelegate {
     
     func success(result: TextToSpeechResult) {
         TOCK() // synthesize timer
-        print(result)
-        self.streamingFile = result.url
+        guard let url = result.url else {
+            return
+        }
+        self.streamingFile = url
         if (self.amTesting) {
             self.playTest()
             //self.download(url)

--- a/SpokestackTests/TextToSpeechTest.swift
+++ b/SpokestackTests/TextToSpeechTest.swift
@@ -41,6 +41,7 @@ class TextToSpeechTest: XCTestCase {
         XCTAssert(delegate.didSucceed)
         XCTAssertFalse(delegate.didFail)
         
+        // successful request with ssml formatting
         delegate.reset()
         let didSucceedExpectation2 = expectation(description: "successful request calls TestTextToSpeechDelegate.success")
         delegate.asyncExpectation = didSucceedExpectation2

--- a/SpokestackTests/TextToSpeechTest.swift
+++ b/SpokestackTests/TextToSpeechTest.swift
@@ -71,7 +71,6 @@ class TextToSpeechTest: XCTestCase {
 }
 
 class TestTextToSpeechDelegate: TextToSpeechDelegate {
-
     /// Spy pattern for the system under test.
     /// asyncExpectation lets the caller's test know when the delegate has been called.
     var didSucceed: Bool = false
@@ -89,7 +88,7 @@ class TestTextToSpeechDelegate: TextToSpeechDelegate {
         asyncExpectation = .none
     }
     
-    func success(url: URL) {
+    func success(result: TextToSpeechResult) {
         asyncExpectation?.fulfill()
         didSucceed = true
     }

--- a/SpokestackTests/TextToSpeechTest.swift
+++ b/SpokestackTests/TextToSpeechTest.swift
@@ -10,6 +10,7 @@ import Foundation
 import XCTest
 import Spokestack
 
+@available(iOS 13, *)
 class TextToSpeechTest: XCTestCase {
     
     /// MARK: Synthesize
@@ -20,7 +21,7 @@ class TextToSpeechTest: XCTestCase {
         // bad config results in a failed request that calls failure
         let badConfig = SpeechConfiguration()
         let didFailConfigExpectation = expectation(description: "bad config results in a failed request that calls TestTextToSpeechDelegate.failure")
-        badConfig.authorization = "BADBADNOTGOOD"
+        badConfig.apiId = "BADBADNOTGOOD"
         let badTTS = TextToSpeech(delegate, configuration: badConfig)
         delegate.asyncExpectation = didFailConfigExpectation
         badTTS.synthesize(input)
@@ -43,22 +44,11 @@ class TextToSpeechTest: XCTestCase {
         delegate.reset()
         let didSucceedExpectation2 = expectation(description: "successful request calls TestTextToSpeechDelegate.success")
         delegate.asyncExpectation = didSucceedExpectation2
-        let ssmlInput = TextToSpeechInput("<speak>Yet right now the average age of this 52nd Parliament is 49 years old, <break time='500ms'/> OK Boomer.</speak>", voice: "demo-male", inputFormat: .ssml)
+        let ssmlInput = TextToSpeechInput("<speak>Yet right now the average age of this 52nd Parliament is 49 years old, <break time='500ms'/> OK Boomer.</speak>", voice: .demoMale, inputFormat: .ssml)
         tts.synthesize(ssmlInput)
         wait(for: [didSucceedExpectation2], timeout: 5)
         XCTAssert(delegate.didSucceed)
         XCTAssertFalse(delegate.didFail)
-        
-        // bad input results in a failed request that calls failure
-        delegate.reset()
-        let didFailInputExpectation = expectation(description: "bad input results in a failed request that calls TestTextToSpeechDelegate.failure")
-        let badInput = TextToSpeechInput()
-        badInput.voice = "marvin"
-        delegate.asyncExpectation = didFailInputExpectation
-        tts.synthesize(badInput)
-        wait(for: [didFailInputExpectation], timeout: 5)
-        XCTAssert(delegate.didFail)
-        XCTAssertFalse(delegate.didSucceed)
     }
     
     /// MARK:  Speak


### PR DESCRIPTION
Revised TTS API to use new HMAC+GraphQL service. This new service required a couple of deprecations to the existing library API, namely the new `TextToSpeechResult` class replaces `URL`, and no longer supporting plain-text `TextToSpeechInput`. HMAC support requires iOS 13+. The new service supports an optional client-supplied request identifier, which is echoed in the result.