### PR TITLE
Remove ambiguous function from API; add test and docs for TextToSpeech.synthesize publisher

### DIFF
--- a/Spokestack-iOS.podspec
+++ b/Spokestack-iOS.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'Spokestack-iOS'
   s.module_name = 'Spokestack'
-  s.version = '6.1.0'
+  s.version = '7.0.0'
   s.license = 'Apache'
   s.summary = 'Spokestack provides an extensible speech recognition pipeline for the iOS platform.'
   s.homepage = 'https://www.spokestack.io'

--- a/Spokestack.xcodeproj/project.pbxproj
+++ b/Spokestack.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		59E0E13E230DEB7C0060F012 /* Detect.lite in Resources */ = {isa = PBXBuildFile; fileRef = 59E0E13B230DEB7C0060F012 /* Detect.lite */; };
 		59E0E13F230DEB7C0060F012 /* Encode.lite in Resources */ = {isa = PBXBuildFile; fileRef = 59E0E13C230DEB7C0060F012 /* Encode.lite */; };
 		59E0E140230DEB7C0060F012 /* Filter.lite in Resources */ = {isa = PBXBuildFile; fileRef = 59E0E13D230DEB7C0060F012 /* Filter.lite */; };
+		59ECA8C823C939AA003CDB57 /* TextToSpeechResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D972BB23C592A00002FF79 /* TextToSpeechResult.swift */; };
 		59EF51BF233013A9006BA0BD /* AppleSpeechRecognizerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EF51BE233013A9006BA0BD /* AppleSpeechRecognizerTest.swift */; };
 		59EF51C123328D57006BA0BD /* AppleWakewordRecognizerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EF51C023328D57006BA0BD /* AppleWakewordRecognizerTest.swift */; };
 		59EF51C32332E57B006BA0BD /* Frame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EF51C22332E57B006BA0BD /* Frame.swift */; };
@@ -742,6 +743,7 @@
 				59C2AFDF2319CE8000E47AC5 /* SpeechProcessor.swift in Sources */,
 				5936077F236B688400FFA29F /* WebRTCVAD.swift in Sources */,
 				59D78F5F2322D13700728A98 /* AudioControllerTest.swift in Sources */,
+				59ECA8C823C939AA003CDB57 /* TextToSpeechResult.swift in Sources */,
 				5942C4362384772600EC0B13 /* TextToSpeechDelegate.swift in Sources */,
 				59A8DBF92384ABF000F97700 /* TextToSpeechTest.swift in Sources */,
 				59C2AFE82319CF3900E47AC5 /* FFT.swift in Sources */,

--- a/Spokestack/SpeechConfiguration.swift
+++ b/Spokestack/SpeechConfiguration.swift
@@ -102,8 +102,10 @@ import Foundation
     @available(*, deprecated, message: "Authorization key is no longer supported for Text To Speech service, use apiId + apiKey instead.")
     @objc public var authorization: String = "Key f854fbf30a5f40c189ecb1b38bc78059"
     /// Text To Speech API client identifier key.
+    /// - SeeAlso: `TextToSpeech`
     @objc public var apiId: String = "f0bc990c-e9db-4a0c-a2b1-6a6395a3d97e"
     /// Text To Speech API client secret key.
+    /// - SeeAlso: `TextToSpeech`
     @objc public var apiSecret: String = "5BD5483F573D691A15CFA493C1782F451D4BD666E39A9E7B2EBE287E6A72C6B6"
     /// Debugging trace levels, for simple filtering.
     @objc public var tracing: Trace.Level = Trace.Level.NONE

--- a/Spokestack/SpeechConfiguration.swift
+++ b/Spokestack/SpeechConfiguration.swift
@@ -103,7 +103,7 @@ import Foundation
     @objc public var authorization: String = "Key f854fbf30a5f40c189ecb1b38bc78059"
     /// Text To Speech API client identifier key.
     @objc public var apiId: String = "f0bc990c-e9db-4a0c-a2b1-6a6395a3d97e"
-    /// Text To Speech API client secret key
+    /// Text To Speech API client secret key.
     @objc public var apiSecret: String = "5BD5483F573D691A15CFA493C1782F451D4BD666E39A9E7B2EBE287E6A72C6B6"
     /// Debugging trace levels, for simple filtering.
     @objc public var tracing: Trace.Level = Trace.Level.NONE

--- a/Spokestack/SpeechConfiguration.swift
+++ b/Spokestack/SpeechConfiguration.swift
@@ -101,10 +101,10 @@ import Foundation
     /// Text To Speech API authorization key
     @available(*, deprecated, message: "Authorization key is no longer supported for Text To Speech service, use apiId + apiKey instead.")
     @objc public var authorization: String = "Key f854fbf30a5f40c189ecb1b38bc78059"
-    /// Text To Speech API client identifier.
+    /// Text To Speech API client identifier key.
     @objc public var apiId: String = "f0bc990c-e9db-4a0c-a2b1-6a6395a3d97e"
     /// Text To Speech API client secret key
-    @objc public var apiKey: String = "5BD5483F573D691A15CFA493C1782F451D4BD666E39A9E7B2EBE287E6A72C6B6"
+    @objc public var apiSecret: String = "5BD5483F573D691A15CFA493C1782F451D4BD666E39A9E7B2EBE287E6A72C6B6"
     /// Debugging trace levels, for simple filtering.
     @objc public var tracing: Trace.Level = Trace.Level.NONE
 }

--- a/Spokestack/TextToSpeech.swift
+++ b/Spokestack/TextToSpeech.swift
@@ -44,6 +44,20 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
     private let decoder = JSONDecoder()
     
     // MARK: Initializers
+
+    /// Initializes a new text to speech instance.
+    /// - Parameter delegate: Delegate that receives text to speech events.
+    /// - Parameter configuration: Speech configuration parameters.
+    @objc public init(configuration: SpeechConfiguration) throws {
+        self.configuration = configuration
+        // create a symmetric key using the configured api secret key
+        if let apiSecretEncoded = self.configuration.apiSecret.data(using: .utf8) {
+            self.apiKey = SymmetricKey(data: apiSecretEncoded)
+        } else {
+            throw TextToSpeechErrors.apiKey("Unable to encode apiSecret.")
+        }
+        super.init()
+    }
     
     /// Initializes a new text to speech instance.
     /// - Parameter delegate: Delegate that receives text to speech events.

--- a/Spokestack/TextToSpeech.swift
+++ b/Spokestack/TextToSpeech.swift
@@ -51,11 +51,11 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
     @objc public init(_ delegate: TextToSpeechDelegate, configuration: SpeechConfiguration) {
         self.delegate = delegate
         self.configuration = configuration
-        // create a symmetric key using the configured api key
-        if let apiKeyEncoded = self.configuration.apiKey.data(using: .utf8) {
-            self.apiKey = SymmetricKey(data: apiKeyEncoded)
+        // create a symmetric key using the configured api secret key
+        if let apiSecretEncoded = self.configuration.apiSecret.data(using: .utf8) {
+            self.apiKey = SymmetricKey(data: apiSecretEncoded)
         } else {
-            self.delegate?.failure(error: TextToSpeechErrors.apiKey("Unable to encode apiKey."))
+            self.delegate?.failure(error: TextToSpeechErrors.apiKey("Unable to encode apiSecret."))
         }
         super.init()
     }
@@ -247,7 +247,7 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
         
         // create an authentication code for this request using the symmetric key
         guard let key = self.apiKey else {
-            throw TextToSpeechErrors.apiKey("apiKey is not configured.")
+            throw TextToSpeechErrors.apiKey("apiSecret is not configured.")
         }
         let code = HMAC<SHA256>.authenticationCode(for: request.httpBody!, using: key)
         // turn the code into a string, base64 encoded

--- a/Spokestack/TextToSpeech.swift
+++ b/Spokestack/TextToSpeech.swift
@@ -29,7 +29,7 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
  tts.speak(input) // synthesize the same input as above, and play back the result using the default audio system.
  ```
  
- Using the TTS system requires setting an API client identifier (`SpeechConfgiruation.apiId`) and API client secret (`SpeechConfgiruation.apiSecret`) , which are used to cryptographically sign and meter TTS API usage.
+ Using the TTS system requires setting an API client identifier (`SpeechConfiguration.apiId`) and API client secret (`SpeechConfiguration.apiSecret`) , which are used to cryptographically sign and meter TTS API usage.
  */
 @available(iOS 13.0, *)
 @objc public class TextToSpeech: NSObject {
@@ -48,7 +48,8 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
     // MARK: Initializers
 
     /// Initializes a new text to speech instance without a delegate.
-    /// - Note: An instance initialized this was is expected to use the pub/sub Combine interface, not the delegate interface, when calling `synthesize`.
+    /// - Note: An instance initialized this way is expected to use the pub/sub Combine interface, not the delegate interface, when calling `synthesize`.
+    /// - Requires: `SpeechConfiguration.apiId` and `SpeechConfiguration.apiSecret`.
     /// - Parameter configuration: Speech configuration parameters.
     @objc public init(configuration: SpeechConfiguration) throws {
         self.configuration = configuration
@@ -63,6 +64,7 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
     
     /// Initializes a new text to speech instance.
     /// - Parameter delegate: Delegate that receives text to speech events.
+    /// - Requires: `SpeechConfiguration.apiId` and `SpeechConfiguration.apiSecret`.
     /// - Parameter configuration: Speech configuration parameters.
     @objc public init(_ delegate: TextToSpeechDelegate, configuration: SpeechConfiguration) {
         self.delegate = delegate

--- a/Spokestack/TextToSpeech.swift
+++ b/Spokestack/TextToSpeech.swift
@@ -113,7 +113,7 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
     
     // MARK: Public methods
     
-    /// Synthesize speech using the provided input parameters and speech configuration. A successful synthesis will return a URL to the streaming audio container of synthesized speech to the `TextToSpeech`'s `delegate`. Maps a list of `TextToSpeechResults`
+    /// Synthesize speech using the provided list of inputs. A successful set of synthesises returns a list of synthesis results.
     /// - Parameter inputs: `Array` of `TextToSpeechInput`
     /// - Returns: `AnyPublisher<[TextToSpeechResult], Error>`
     public func synthesize(_ inputs: Array<TextToSpeechInput>) -> AnyPublisher<[TextToSpeechResult], Error> {

--- a/Spokestack/TextToSpeech.swift
+++ b/Spokestack/TextToSpeech.swift
@@ -17,7 +17,7 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
 /**
  This is the client entry point for the Spokestack Text to Speech (TTS) system. It provides the capability to synthesize textual input, and speak back the synthesis as audio system output. The synthesis and speech occur on asynchronous blocks so as to not block the client while it performs network and audio system activities.
  
- When inititalized,  the TTS system communicates with the client via delegates that receive events.
+ When inititalized, the TTS system communicates with the client either via a delegate that receive events, or via a publisher-subscriber pattern.
  
  ```
  // assume that self implements the TextToSpeechDelegate protocol.
@@ -28,6 +28,8 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
  tts.synthesize(input) // synthesize the provided default text input using the default synthetic voice and api key.
  tts.speak(input) // synthesize the same input as above, and play back the result using the default audio system.
  ```
+ 
+ Using the TTS system requires setting an API client identifier (`SpeechConfgiruation.apiId`) and API client secret (`SpeechConfgiruation.apiSecret`) , which are used to cryptographically sign and meter TTS API usage.
  */
 @available(iOS 13.0, *)
 @objc public class TextToSpeech: NSObject {
@@ -45,8 +47,8 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
     
     // MARK: Initializers
 
-    /// Initializes a new text to speech instance.
-    /// - Parameter delegate: Delegate that receives text to speech events.
+    /// Initializes a new text to speech instance without a delegate.
+    /// - Note: An instance initialized this was is expected to use the pub/sub Combine interface, not the delegate interface, when calling `synthesize`.
     /// - Parameter configuration: Speech configuration parameters.
     @objc public init(configuration: SpeechConfiguration) throws {
         self.configuration = configuration

--- a/SpokestackFrameworkExample/TTSViewController.swift
+++ b/SpokestackFrameworkExample/TTSViewController.swift
@@ -158,7 +158,7 @@ class TTSViewController: UIViewController {
         if (text == "") { text = "You didn't enter any text to synthesize." }
         let input = TextToSpeechInput("<speak>\(text)</speak>")
         input.inputFormat = .ssml
-        let _: Void? = self.tts?.synthesize(input)
+        self.tts?.synthesize(input)
     }
     
     @objc func playAction(_ sender: Any) {

--- a/SpokestackFrameworkExample/TTSViewController.swift
+++ b/SpokestackFrameworkExample/TTSViewController.swift
@@ -158,7 +158,7 @@ class TTSViewController: UIViewController {
         if (text == "") { text = "You didn't enter any text to synthesize." }
         let input = TextToSpeechInput("<speak>\(text)</speak>")
         input.inputFormat = .ssml
-        self.tts?.synthesize(input)
+        let _: Void? = self.tts?.synthesize(input)
     }
     
     @objc func playAction(_ sender: Any) {

--- a/SpokestackTests/TextToSpeechTest.swift
+++ b/SpokestackTests/TextToSpeechTest.swift
@@ -54,7 +54,10 @@ class TextToSpeechTest: XCTestCase {
     
     func testSynthesizePublisher() {
         let config = SpeechConfiguration()
-        let tts = TextToSpeech(configuration: config)
+        guard let tts = try? TextToSpeech(configuration: config) else {
+            XCTFail("could not initialize TextToSpeech class")
+            return
+        }
         let input = TextToSpeechInput()
 
         // successful request

--- a/SpokestackTests/TextToSpeechTest.swift
+++ b/SpokestackTests/TextToSpeechTest.swift
@@ -24,7 +24,7 @@ class TextToSpeechTest: XCTestCase {
         badConfig.apiId = "BADBADNOTGOOD"
         let badTTS = TextToSpeech(delegate, configuration: badConfig)
         delegate.asyncExpectation = didFailConfigExpectation
-        let _: Void = badTTS.synthesize(input)
+        badTTS.synthesize(input)
         wait(for: [didFailConfigExpectation], timeout: 5)
         XCTAssert(delegate.didFail)
         XCTAssertFalse(delegate.didSucceed)
@@ -36,7 +36,7 @@ class TextToSpeechTest: XCTestCase {
         delegate.reset()
         let didSucceedExpectation = expectation(description: "successful request calls TestTextToSpeechDelegate.success")
         delegate.asyncExpectation = didSucceedExpectation
-        let _: Void = tts.synthesize(input)
+        tts.synthesize(input)
         wait(for: [didSucceedExpectation], timeout: 5)
         XCTAssert(delegate.didSucceed)
         XCTAssertFalse(delegate.didFail)
@@ -46,7 +46,7 @@ class TextToSpeechTest: XCTestCase {
         let didSucceedExpectation2 = expectation(description: "successful request calls TestTextToSpeechDelegate.success")
         delegate.asyncExpectation = didSucceedExpectation2
         let ssmlInput = TextToSpeechInput("<speak>Yet right now the average age of this 52nd Parliament is 49 years old, <break time='500ms'/> OK Boomer.</speak>", voice: .demoMale, inputFormat: .ssml)
-        let _: Void = tts.synthesize(ssmlInput)
+        tts.synthesize(ssmlInput)
         wait(for: [didSucceedExpectation2], timeout: 5)
         XCTAssert(delegate.didSucceed)
         XCTAssertFalse(delegate.didFail)


### PR DESCRIPTION
This is a breaking API change from what was just published in 6.1. 
- Config value `apiKey` has been renamed `apiSecret`
- Clang is unable to distinguish between a function call with a discarded return type and a function call to a `Void` return type without some ugliness on the client end (eg `let _: Void = functionWithOverloadedReturnTypes`). To resolve this, the function ` synthesize(_ input: TextToSpeechInput) -> AnyPublisher<TextToSpeechResult, Error>` has been removed. 

*Discussion*:
Clients can still use `synthesize(_ inputs: Array<TextToSpeechInput>) -> AnyPublisher<[TextToSpeechResult], Error>`, and for use cases where a single input is provided, just use a list of inputs of length 1. 