### PR TITLE
Configurable dispatch queue for delivery of delegate events

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Activity Detection (VAD), wakeword activation, and Automatic Speech Recognition 
 * [Features](#features)
 * [Installation](#installation)
 * [Usage](#usage)
-* [API Reference](#api-reference)
+* [Documentation](#Documentation)
 * [Deployment](#Deployment)
 * [License](#license)
 <!--te-->
@@ -47,6 +47,22 @@ This example creates a speech recognition pipeline using a wakeword detector tha
 
 See `SpeechPipeline` and `SpeechConfiguration` for further configuration documentation.
 
+### Text to Speech
+
+```
+// assume that self implements the TextToSpeechDelegate protocol
+let tts = TextToSpeech(self, configuration: SpeechConfiguration())
+tts.speak(TextToSpeechInput("My god, it's full of stars!"))
+```
+
+### Natural Language Understanding
+
+```
+// assume that self implements the NLUDelegate protocol
+let nlu = try! NLUTensorflow(self, configuration: configuration)
+nlu.classify(utterance: "I can't turn that light in the room on for you, Dave", context: [:])
+```
+
 ### Reference implementation
 
 The `SpokestackFrameworkExample` project contains reference implementations for how to use the Spokestack library, along with runnable examples of the wakeword and ASR components. Each component has a corresponding screen from the main screen, and can be started, stopped, or synthesized, as appropriate. The component screens have full debug tracing enabled, so the system control logic and debug events will appear in the XCode Console.
@@ -55,7 +71,13 @@ The `SpokestackFrameworkExample` project contains reference implementations for 
 
 A build error similar to `Code Sign error: No unexpired provisioning profiles found that contain any of the keychain's signing certificates` will occur if the bundle identifier is not changed from `io.Spokestack.SpokestackFrameworkExample`, which is tied to the Spokestack organization. 
 
-## API Reference
+## Documentation
+
+### Getting Started, Cookbooks, and Conceptual Guides
+
+[Step-by-step introduction](https://spokestack.io/docs/iOS/getting-started), [common usage patterns](https://spokestack.io/docs/iOS/cookbook), and [discussion of concepts](https://spokestack.io/docs/Concepts/pipeline-configuration) used by the library, [design guides for voice interfaces](https://spokestack.io/docs/Design/getting-started), and [the Android library](https://spokestack.io/docs/Android/getting-started) may all be found [on our website](https://spokestack.io/docs).
+
+### API Reference
 
 API reference is [available on Github](https://spokestack.github.io/spokestack-ios/index.html).
 
@@ -76,7 +98,7 @@ API reference is [available on Github](https://spokestack.github.io/spokestack-i
 ## License
 [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
 
-Copyright 2018 Pylon, Inc.
+Copyright 2020 Spokestack, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/Spokestack.xcodeproj/xcshareddata/xcschemes/Spokestack.xcscheme
+++ b/Spokestack.xcodeproj/xcshareddata/xcschemes/Spokestack.xcscheme
@@ -26,7 +26,9 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -36,6 +38,15 @@
             ReferencedContainer = "container:Spokestack.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "01D31F3A216BAF260055FD45"
+            BuildableName = "Spokestack.framework"
+            BlueprintName = "Spokestack"
+            ReferencedContainer = "container:Spokestack.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Spokestack/AppleWakewordRecognizer.swift
+++ b/Spokestack/AppleWakewordRecognizer.swift
@@ -103,7 +103,7 @@ This pipeline component uses the Apple `SFSpeech` API to stream audio samples fo
                 self?.stopRecognition()
                 self?.startRecognition()
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(self.configuration!.wakewordRequestTimeout), execute: self.dispatchWorker!)
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + .milliseconds(self.configuration!.wakewordRequestTimeout), execute: self.dispatchWorker!)
         } catch let error {
             self.delegate?.didError(error)
         }

--- a/Spokestack/AppleWakewordRecognizer.swift
+++ b/Spokestack/AppleWakewordRecognizer.swift
@@ -105,7 +105,9 @@ This pipeline component uses the Apple `SFSpeech` API to stream audio samples fo
             }
             DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + .milliseconds(self.configuration!.wakewordRequestTimeout), execute: self.dispatchWorker!)
         } catch let error {
-            self.delegate?.didError(error)
+            self.configuration?.delegateDispatchQueue.async {
+                self.delegate?.didError(error)
+            }
         }
     }
     
@@ -135,7 +137,7 @@ This pipeline component uses the Apple `SFSpeech` API to stream audio samples fo
                         if nse.domain == "kAFAssistantErrorDomain" {
                             switch nse.code {
                             case 0..<200: // Apple retry error: https://developer.nuance.com/public/Help/DragonMobileSDKReference_iOS/Error-codes.html
-                                Trace.trace(Trace.Level.INFO, configLevel: strongSelf.traceLevel, message: "resultHandler error \(nse.code.description)", delegate: strongSelf.delegate, caller: strongSelf)
+                                Trace.trace(Trace.Level.INFO, config: strongSelf.configuration, message: "resultHandler error \(nse.code.description)", delegate: strongSelf.delegate, caller: strongSelf)
                                 break
                             case 203: // request timed out, retry
                                 strongSelf.stopRecognition()
@@ -146,10 +148,12 @@ This pipeline component uses the Apple `SFSpeech` API to stream audio samples fo
                             case 216: // Apple internal error: https://stackoverflow.com/questions/53037789/sfspeechrecognizer-216-error-with-multiple-requests?noredirect=1&lq=1)
                                 break
                             case 300..<603: // Apple retry error: https://developer.nuance.com/public/Help/DragonMobileSDKReference_iOS/Error-codes.html
-                                Trace.trace(Trace.Level.INFO, configLevel: strongSelf.traceLevel, message: "resultHandler error \(nse.code.description)", delegate: strongSelf.delegate, caller: strongSelf)
+                                Trace.trace(Trace.Level.INFO, config: strongSelf.configuration, message: "resultHandler error \(nse.code.description)", delegate: strongSelf.delegate, caller: strongSelf)
                                 break
                             default:
-                                delegate.didError(e)
+                                strongSelf.configuration?.delegateDispatchQueue.async {
+                                    delegate.didError(e)
+                                }
                             }
                         }
                     } else {
@@ -157,7 +161,7 @@ This pipeline component uses the Apple `SFSpeech` API to stream audio samples fo
                     }
                 }
                 if let r = result {
-                    Trace.trace(Trace.Level.DEBUG, configLevel: strongSelf.traceLevel, message: "hears \(r.bestTranscription.formattedString)", delegate: strongSelf.delegate, caller: strongSelf)
+                    Trace.trace(Trace.Level.DEBUG, config: strongSelf.configuration, message: "hears \(r.bestTranscription.formattedString)", delegate: strongSelf.delegate, caller: strongSelf)
                     let wakewordDetected: Bool =
                         !strongSelf.phrases
                             .filter({
@@ -169,7 +173,9 @@ This pipeline component uses the Apple `SFSpeech` API to stream audio samples fo
                             .isEmpty
                     if wakewordDetected {
                         strongSelf.context.isActive = true
-                        delegate.activate()
+                        strongSelf.configuration?.delegateDispatchQueue.async {
+                            delegate.activate()
+                        }
                     }
                 }
         })
@@ -218,7 +224,9 @@ extension AppleWakewordRecognizer: AudioControllerDelegate {
             guard let strongSelf = self else { return }
             do { try strongSelf.vad.process(frame: frame, isSpeech: false) } // TODO: this will only trigger VAD activation the first time, and run the ASR continuously subsequently.
             catch let error {
-                strongSelf.delegate?.didError(error)
+                strongSelf.configuration?.delegateDispatchQueue.async {
+                    strongSelf.delegate?.didError(error)
+                }
             }
         }
     }
@@ -239,7 +247,9 @@ extension AppleWakewordRecognizer: VADDelegate {
                 try self.audioEngine.start()
                 self.startRecognition()
             } catch let error {
-                self.delegate?.didError(error)
+                self.configuration?.delegateDispatchQueue.async {
+                    self.delegate?.didError(error)
+                }
             }
         }
     }

--- a/Spokestack/AudioController.swift
+++ b/Spokestack/AudioController.swift
@@ -8,9 +8,10 @@
 
 import Foundation
 import AVFoundation
+import Dispatch
 
 /// DispatchQueue for handling Spokestack audio processing
-let audioProcessingQueue: DispatchQueue = DispatchQueue(label: "io.spokestack.audio.callback")
+let audioProcessingQueue: DispatchQueue = DispatchQueue.global(qos: .userInteractive)
 
 /// Required callback function for AudioUnitSetProperty's AURenderCallbackStruct.
 ///
@@ -50,6 +51,9 @@ func recordingCallback(
         
     if buffers[0].mData != nil {
         let data: Data = Data(bytes: buffers[0].mData!, count: Int(buffers[0].mDataByteSize))
+        // NB: errors like
+        // AUBuffer.h:61:GetBufferList: EXCEPTION (-1) [mPtrState == kPtrsInvalid is false]: ""
+        // are irrelevant
         audioProcessingQueue.sync {
             AudioController.sharedInstance.delegate?.process(data)
         }

--- a/Spokestack/NLUTensorflow.swift
+++ b/Spokestack/NLUTensorflow.swift
@@ -93,7 +93,7 @@ import TensorFlowLite
     /// Classifies the provided input. The classifciation results are sent to the instance's configured NLUDelegate.
     /// - Parameter utterance: The provided utterance to classify.
     @objc public func classify(utterance: String, context: [String : Any]) -> Void {
-        DispatchQueue.main.async {
+        DispatchQueue.global(qos: .userInitiated).async {
             let prediction = self.classify(utterance)
             switch prediction {
             case .success(let classification): self.delegate?.classification(result: classification)

--- a/Spokestack/NLUTensorflow.swift
+++ b/Spokestack/NLUTensorflow.swift
@@ -10,7 +10,20 @@ import Foundation
 import Combine
 import TensorFlowLite
 
-/// A BERT NLU implementation.
+/** A BERT NLU implementation.
+ 
+    This class provides a classification interface for deriving intents and slots from a natural language utterance.
+ 
+    When inititalized, the TTS system communicates with the client either via a delegate that receive events, or via a publisher-subscriber pattern.
+ 
+ ```
+ // assume that self implements the NLUDelegate protocol
+ let nlu = try! NLUTensorflow(self, configuration: configuration)
+ nlu.classify(utterance: "I can't turn that light in the room on for you, Dave", context: [:])
+ ```
+ 
+    Using the NLUTensorflow class requires the providing a number of `SpeechConfiguration` variables, all prefixed with `nlu`. The most important are the `nluVocabularyPath`, `nluModelPath`, and the `nluModelMetadataPath`.
+ */
 @objc public class NLUTensorflow: NSObject, NLUService {
     
     /// Configuration parameters for the NLU.
@@ -62,7 +75,9 @@ import TensorFlowLite
             super.init()
             try self.configure()
         } catch let error {
-            delegate.failure(error: error)
+            self.configuration.delegateDispatchQueue.async {
+                delegate.failure(error: error)
+            }
         }
     }
     
@@ -90,15 +105,20 @@ import TensorFlowLite
         }
     }
     
-    /// Classifies the provided input. The classifciation results are sent to the instance's configured NLUDelegate.
+    /// Classifies the provided input. The classification results are sent to the instance's configured NLUDelegate.
     /// - Parameter utterance: The provided utterance to classify.
     @objc public func classify(utterance: String, context: [String : Any]) -> Void {
         DispatchQueue.global(qos: .userInitiated).async {
             let prediction = self.classify(utterance)
             switch prediction {
-            case .success(let classification): self.delegate?.classification(result: classification)
+            case .success(let classification):
+                self.configuration.delegateDispatchQueue.async {
+                    self.delegate?.classification(result: classification)
+                }
             case .failure(let error):
-                self.delegate?.failure(error: error)
+                self.configuration.delegateDispatchQueue.async {
+                    self.delegate?.failure(error: error)
+                }
             }
         }
     }
@@ -136,7 +156,7 @@ import TensorFlowLite
             encodedTokens
                 += [self.terminatorToken]
                 + Array(repeating: self.paddingToken, count: self.configuration.nluMaxTokenLength - encodedTokens.count - 1)
-            Trace.trace(Trace.Level.DEBUG, configLevel: self.configuration.tracing, message: "classify encoded tokens: \(encodedTokens)", delegate: self.delegate, caller: self)
+            Trace.trace(Trace.Level.DEBUG, config: self.configuration, message: "classify encoded tokens: \(encodedTokens)", delegate: self.delegate, caller: self)
             // downcast the (assumed iOS) default Int64 to match the model's expected Int32 size. This is safe because the model vocabulary code indicies are 32-bit.
             let downcastEncodedInput = encodedTokens.map { Int32(truncatingIfNeeded: $0) }
             _ = try downcastEncodedInput
@@ -171,7 +191,7 @@ import TensorFlowLite
         }
         var intent = metadata.model.intents[intentsArgmax.0]
         intent.confidence = intentsArgmax.1
-        Trace.trace(Trace.Level.DEBUG, configLevel: self.configuration.tracing, message: "classify intent: \(intent)", delegate: self.delegate, caller: self)
+        Trace.trace(Trace.Level.DEBUG, config: self.configuration, message: "classify intent: \(intent)", delegate: self.delegate, caller: self)
         return intent
     }
     
@@ -186,10 +206,10 @@ import TensorFlowLite
                                        to: encodedTags.count,
                                        by: metadata.model.tags.count)
             .map { Array(encodedTags[$0..<$0+metadata.model.tags.count]).argmax() }
-        Trace.trace(Trace.Level.DEBUG, configLevel: self.configuration.tracing, message: "classify argmaxes: \(encodedTagsArgmax)", delegate: self.delegate, caller: self)
+        Trace.trace(Trace.Level.DEBUG, config: self.configuration, message: "classify argmaxes: \(encodedTagsArgmax)", delegate: self.delegate, caller: self)
         // decode the tags according to the model metadata index
         let tagsByInput = encodedTagsArgmax.map { metadata.model.tags[$0.0] }
-        Trace.trace(Trace.Level.DEBUG, configLevel: self.configuration.tracing, message: "classify tags: \(tagsByInput)", delegate: self.delegate, caller: self)
+        Trace.trace(Trace.Level.DEBUG, config: self.configuration, message: "classify tags: \(tagsByInput)", delegate: self.delegate, caller: self)
         // hydrate Slot objects according to the tag
         return try parser.parse(tags: tagsByInput, intent: intent, encoder: tokenizer, encodedTokens: encodedInput)
     }

--- a/Spokestack/SpeechConfiguration.swift
+++ b/Spokestack/SpeechConfiguration.swift
@@ -127,4 +127,6 @@ import Foundation
     @objc public var nluMaxTokenLength: Int = 128
     /// Debugging trace levels, for simple filtering.
     @objc public var tracing: Trace.Level = Trace.Level.NONE
+    /// Delegate events will be sent using the specified dispatch queue.
+    @objc public var delegateDispatchQueue: DispatchQueue = DispatchQueue.global(qos: .userInitiated)
 }

--- a/Spokestack/SpeechPipeline.swift
+++ b/Spokestack/SpeechPipeline.swift
@@ -24,8 +24,6 @@ import Foundation
                                pipelineDelegate: self)
  pipeline.start()
  ```
- 
- - Warning: All calls to delegate event handlers are made in the context of the pipeline's thread, so event handlers should not perform blocking operations, and they should use message passing when communicating with UI components, etc.
 */
 @objc public final class SpeechPipeline: NSObject {
     
@@ -75,7 +73,10 @@ import Foundation
         
         self.pipelineDelegate = pipelineDelegate
         AudioController.sharedInstance.pipelineDelegate = self.pipelineDelegate
-        self.pipelineDelegate?.didInit()
+        super.init()
+        c.delegateDispatchQueue.async {
+            self.pipelineDelegate?.didInit()
+        }
     }
     
     /// Initializes a new speech pipeline instance.
@@ -105,7 +106,10 @@ import Foundation
         
         self.pipelineDelegate = pipelineDelegate
         AudioController.sharedInstance.pipelineDelegate = self.pipelineDelegate
-        self.pipelineDelegate?.didInit()
+        super.init()
+        self.speechConfiguration?.delegateDispatchQueue.async {
+            self.pipelineDelegate?.didInit()
+        }
     }
     
     /// MARK: Pipeline status
@@ -167,7 +171,9 @@ import Foundation
         }
         AudioController.sharedInstance.startStreaming(context: self.context)
         self.wakewordRecognizerService.startStreaming(context: self.context)
-        self.pipelineDelegate?.didStart()
+        self.speechConfiguration?.delegateDispatchQueue.async {
+            self.pipelineDelegate?.didStart()
+        }
     }
     
     /// Stops the speech pipeline.
@@ -177,6 +183,8 @@ import Foundation
         self.speechRecognizerService.stopStreaming(context: self.context)
         self.wakewordRecognizerService.stopStreaming(context: self.context)
         AudioController.sharedInstance.stopStreaming(context: self.context)
-        self.pipelineDelegate?.didStop()
+        self.speechConfiguration?.delegateDispatchQueue.async {
+            self.pipelineDelegate?.didStop()
+        }
     }
 }

--- a/Spokestack/TextToSpeech.swift
+++ b/Spokestack/TextToSpeech.swift
@@ -94,7 +94,7 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
     /// - Warning: `AVAudioSession.Category` and `AVAudioSession.CategoryOptions` must be set by the client to compatible settings that allow for playback through the desired audio sytem ouputs.
     @objc public func speak(_ input: TextToSpeechInput) -> Void {
         func play(result: TextToSpeechResult) {
-            DispatchQueue.main.async {
+            DispatchQueue.global(qos: .userInitiated).async {
                 guard let url = result.url else {
                     self.delegate?.failure(error: TextToSpeechErrors.speak("Synthesis response is invalid."))
                     return
@@ -184,7 +184,7 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
         let task: URLSessionDataTask = session.dataTask(with: request) { (data, response, error) -> Void in
             Trace.trace(Trace.Level.DEBUG, configLevel: self.configuration.tracing, message: "task callback \(String(describing: response)) \(String(describing: String(data: data ?? Data(), encoding: String.Encoding.utf8)))) \(String(describing: error))", delegate: self.delegate, caller: self)
             
-            DispatchQueue.main.async {
+            DispatchQueue.global(qos: .userInitiated).async {
                 if let error = error {
                     self.delegate?.failure(error: error)
                 } else {
@@ -286,7 +286,7 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
     /// - Warning: Client should never call this function.
     @available(*, deprecated, message: "Internal function that must be public for Objective-C compatibility reasons. Client should never call this function.")
     override public func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        DispatchQueue.main.async {
+        DispatchQueue.global(qos: .userInitiated).async {
             switch keyPath {
             case #keyPath(AVPlayerItem.isPlaybackBufferEmpty):
                 self.player.play()

--- a/Spokestack/TextToSpeech.swift
+++ b/Spokestack/TextToSpeech.swift
@@ -48,7 +48,7 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
     // MARK: Initializers
 
     /// Initializes a new text to speech instance without a delegate.
-    /// - Note: An instance initialized this way is expected to use the pub/sub Combine interface, not the delegate interface, when calling `synthesize`.
+    /// - Warning: An instance initialized this way is expected to use the pub/sub `Combine` interface, not the delegate interface, when calling `synthesize`.
     /// - Requires: `SpeechConfiguration.apiId` and `SpeechConfiguration.apiSecret`.
     /// - Parameter configuration: Speech configuration parameters.
     @objc public init(configuration: SpeechConfiguration) throws {
@@ -73,7 +73,9 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
         if let apiSecretEncoded = self.configuration.apiSecret.data(using: .utf8) {
             self.apiKey = SymmetricKey(data: apiSecretEncoded)
         } else {
-            self.delegate?.failure(error: TextToSpeechErrors.apiKey("Unable to encode apiSecret."))
+            self.configuration.delegateDispatchQueue.async {
+                delegate.failure(error: TextToSpeechErrors.apiKey("Unable to encode apiSecret."))
+            }
         }
         super.init()
     }
@@ -96,7 +98,9 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
         func play(result: TextToSpeechResult) {
             DispatchQueue.global(qos: .userInitiated).async {
                 guard let url = result.url else {
-                    self.delegate?.failure(error: TextToSpeechErrors.speak("Synthesis response is invalid."))
+                    self.configuration.delegateDispatchQueue.async {
+                        self.delegate?.failure(error: TextToSpeechErrors.speak("Synthesis response is invalid."))
+                    }
                     return
                 }
                 let playerItem = AVPlayerItem(url: url)
@@ -172,36 +176,48 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
         do {
             request = try createSynthesizeRequest(input)
         } catch TextToSpeechErrors.apiKey(let message) {
-            self.delegate?.failure(error: TextToSpeechErrors.apiKey(message))
+            self.configuration.delegateDispatchQueue.async {
+                self.delegate?.failure(error: TextToSpeechErrors.apiKey(message))
+            }
             return
         } catch let error {
-            self.delegate?.failure(error: error)
+            self.configuration.delegateDispatchQueue.async {
+                self.delegate?.failure(error: error)
+            }
             return
         }
         
-        Trace.trace(Trace.Level.DEBUG, configLevel: self.configuration.tracing, message: "request \(request.debugDescription) \(String(describing: request.allHTTPHeaderFields)) \(String(data: request.httpBody!, encoding: String.Encoding.utf8) ?? "no body")", delegate: self.delegate, caller: self)
+        Trace.trace(Trace.Level.DEBUG, config: self.configuration, message: "request \(request.debugDescription) \(String(describing: request.allHTTPHeaderFields)) \(String(data: request.httpBody!, encoding: String.Encoding.utf8) ?? "no body")", delegate: self.delegate, caller: self)
         
         let task: URLSessionDataTask = session.dataTask(with: request) { (data, response, error) -> Void in
-            Trace.trace(Trace.Level.DEBUG, configLevel: self.configuration.tracing, message: "task callback \(String(describing: response)) \(String(describing: String(data: data ?? Data(), encoding: String.Encoding.utf8)))) \(String(describing: error))", delegate: self.delegate, caller: self)
+            Trace.trace(Trace.Level.DEBUG, config: self.configuration, message: "task callback \(String(describing: response)) \(String(describing: String(data: data ?? Data(), encoding: String.Encoding.utf8)))) \(String(describing: error))", delegate: self.delegate, caller: self)
             
             DispatchQueue.global(qos: .userInitiated).async {
                 if let error = error {
-                    self.delegate?.failure(error: error)
+                    self.configuration.delegateDispatchQueue.async {
+                        self.delegate?.failure(error: error)
+                    }
                 } else {
                     // unwrap the matryoshka doll that is the response body, responding with a failure if any layer is awry
                     do {
                         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-                            self.delegate?.failure(error: TextToSpeechErrors.deserialization("response cannot be deserialized"))
+                            self.configuration.delegateDispatchQueue.async {
+                                self.delegate?.failure(error: TextToSpeechErrors.deserialization("response cannot be deserialized"))
+                            }
                             return
                         }
                         guard let d = data else {
-                            self.delegate?.failure(error: TextToSpeechErrors.deserialization("response body has no data"))
+                            self.configuration.delegateDispatchQueue.async {
+                                self.delegate?.failure(error: TextToSpeechErrors.deserialization("response body has no data"))
+                            }
                             return
                         }
                         let result = try self.createSynthesizeResponse(data: d, response: httpResponse, inputFormat: input.inputFormat)
                         success?(result)
                     } catch let error {
-                        self.delegate?.failure(error: error)
+                        self.configuration.delegateDispatchQueue.async {
+                            self.delegate?.failure(error: error)
+                        }
                     }
                 }
             }
@@ -210,7 +226,9 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
     }
     
     private func successHandler(result: TextToSpeechResult) {
-        self.delegate?.success(result: result)
+        self.configuration.delegateDispatchQueue.async {
+            self.delegate?.success(result: result)
+        }
     }
     
     // MARK: Internal functions
@@ -278,7 +296,9 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
     @available(*, deprecated, message: "Internal function that must be public for Objective-C compatibility reasons. Client should never call this function.")
     @objc
     func playerDidFinishPlaying(sender: Notification) {
-        self.delegate?.didFinishSpeaking()
+        self.configuration.delegateDispatchQueue.async {
+            self.delegate?.didFinishSpeaking()
+        }
         NotificationCenter.default.removeObserver(self, name: .AVPlayerItemDidPlayToEndTime, object: self.player.currentItem)
     }
     
@@ -290,7 +310,9 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
             switch keyPath {
             case #keyPath(AVPlayerItem.isPlaybackBufferEmpty):
                 self.player.play()
-                self.delegate?.didBeginSpeaking()
+                self.configuration.delegateDispatchQueue.async {
+                    self.delegate?.didBeginSpeaking()
+                }
                 break
             default:
                 break

--- a/Spokestack/WebRTCVAD.swift
+++ b/Spokestack/WebRTCVAD.swift
@@ -37,7 +37,6 @@ public class WebRTCVAD: NSObject {
     
     deinit {
         WebRtcVad_Free(vad.pointee)
-        vad.deallocate()
     }
     
     ///  Creates and configures a new WebRTC VAD component.

--- a/SpokestackFrameworkExample/AppleASRViewController.swift
+++ b/SpokestackFrameworkExample/AppleASRViewController.swift
@@ -117,14 +117,18 @@ extension AppleASRViewController: SpeechEventListener, PipelineDelegate {
     
     func activate() {
         print("activate")
-        self.stopRecordingButton.isEnabled.toggle()
-        self.startRecordingButton.isEnabled.toggle()
+        DispatchQueue.main.async {
+            self.stopRecordingButton.isEnabled.toggle()
+            self.startRecordingButton.isEnabled.toggle()
+        }
     }
     
     func deactivate() {
         print("deactivate")
-        self.stopRecordingButton.isEnabled.toggle()
-        self.startRecordingButton.isEnabled.toggle()
+        DispatchQueue.main.async {
+            self.stopRecordingButton.isEnabled.toggle()
+            self.startRecordingButton.isEnabled.toggle()
+        }
     }
     
     func didError(_ error: Error) {
@@ -137,8 +141,10 @@ extension AppleASRViewController: SpeechEventListener, PipelineDelegate {
     
     func didStart() {
         print("didStart")
-        self.stopRecordingButton.isEnabled.toggle()
-        self.startRecordingButton.isEnabled.toggle()
+        DispatchQueue.main.async {
+            self.stopRecordingButton.isEnabled.toggle()
+            self.startRecordingButton.isEnabled.toggle()
+        }
     }
     
     func didTrace(_ trace: String) {

--- a/SpokestackFrameworkExample/AppleASRViewController.swift
+++ b/SpokestackFrameworkExample/AppleASRViewController.swift
@@ -45,10 +45,12 @@ class AppleASRViewController: UIViewController {
     
     lazy private var pipeline: SpeechPipeline = {
         
-        let appleConfiguration: SpeechConfiguration = SpeechConfiguration()
+        let config: SpeechConfiguration = SpeechConfiguration()
+        config.tracing = .DEBUG
+        config.delegateDispatchQueue = DispatchQueue.main
         
         return SpeechPipeline(SpeechProcessors.appleSpeech.processor,
-                              speechConfiguration: appleConfiguration,
+                              speechConfiguration: config,
                               speechDelegate: self,
                               wakewordService: SpeechProcessors.appleWakeword.processor,
                               pipelineDelegate: self)
@@ -117,18 +119,14 @@ extension AppleASRViewController: SpeechEventListener, PipelineDelegate {
     
     func activate() {
         print("activate")
-        DispatchQueue.main.async {
-            self.stopRecordingButton.isEnabled.toggle()
-            self.startRecordingButton.isEnabled.toggle()
-        }
+        self.stopRecordingButton.isEnabled.toggle()
+        self.startRecordingButton.isEnabled.toggle()
     }
     
     func deactivate() {
         print("deactivate")
-        DispatchQueue.main.async {
-            self.stopRecordingButton.isEnabled.toggle()
-            self.startRecordingButton.isEnabled.toggle()
-        }
+        self.stopRecordingButton.isEnabled.toggle()
+        self.startRecordingButton.isEnabled.toggle()
     }
     
     func didError(_ error: Error) {
@@ -141,10 +139,8 @@ extension AppleASRViewController: SpeechEventListener, PipelineDelegate {
     
     func didStart() {
         print("didStart")
-        DispatchQueue.main.async {
-            self.stopRecordingButton.isEnabled.toggle()
-            self.startRecordingButton.isEnabled.toggle()
-        }
+        self.stopRecordingButton.isEnabled.toggle()
+        self.startRecordingButton.isEnabled.toggle()
     }
     
     func didTrace(_ trace: String) {

--- a/SpokestackFrameworkExample/TFLiteViewController.swift
+++ b/SpokestackFrameworkExample/TFLiteViewController.swift
@@ -13,43 +13,35 @@ import AVFoundation
 class TFLiteViewController: UIViewController {
     
     lazy var startRecordingButton: UIButton = {
-        
         let button: UIButton = UIButton(frame: .zero)
-        
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle("Start", for: .normal)
         button.addTarget(self,
                          action: #selector(TFLiteViewController.startRecordingAction(_:)),
                          for: .touchUpInside)
         button.setTitleColor(.purple, for: .normal)
-        
+        button.isEnabled = true
         return button
     }()
     
     var stopRecordingButton: UIButton = {
-        
         let button: UIButton = UIButton(frame: .zero)
-        
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle("Stop", for: .normal)
         button.addTarget(self,
                          action: #selector(TFLiteViewController.stopRecordingAction(_:)),
                          for: .touchUpInside)
-        
         button.setTitleColor(.purple, for: .normal)
-        
-        
+        button.isEnabled = false
         return button
     }()
     
     private var pipeline: SpeechPipeline?
     
     override func loadView() {
-        
         super.loadView()
         self.view.backgroundColor = .white
         self.title = "TensorFlow Wakeword"
-        
         let doneBarButtonItem: UIBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done,
                                                                  target: self,
                                                                  action: #selector(TFLiteViewController.dismissViewController(_:)))
@@ -58,18 +50,14 @@ class TFLiteViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         self.view.addSubview(self.startRecordingButton)
         self.view.addSubview(self.stopRecordingButton)
-        
         self.startRecordingButton.centerYAnchor.constraint(equalTo: self.view.centerYAnchor).isActive = true
         self.startRecordingButton.leftAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leftAnchor).isActive = true
         self.startRecordingButton.rightAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.rightAnchor).isActive = true
-        
         self.stopRecordingButton.topAnchor.constraint(equalTo: self.startRecordingButton.bottomAnchor, constant: 50.0).isActive = true
         self.stopRecordingButton.leftAnchor.constraint(equalTo: self.startRecordingButton.leftAnchor).isActive = true
         self.stopRecordingButton.rightAnchor.constraint(equalTo: self.startRecordingButton.rightAnchor).isActive = true
-        
         do {
             self.pipeline = try self.initPipeline()
         } catch let error {
@@ -92,6 +80,7 @@ class TFLiteViewController: UIViewController {
         }
         c.detectModelPath = detectPath
         c.tracing = Trace.Level.PERF
+        c.delegateDispatchQueue = DispatchQueue.main
         return SpeechPipeline(SpeechProcessors.appleSpeech.processor,
                               speechConfiguration: c,
                               speechDelegate: self,
@@ -114,10 +103,8 @@ class TFLiteViewController: UIViewController {
     }
     
     func toggleStartStop() {
-        DispatchQueue.main.async {
-            self.stopRecordingButton.isEnabled.toggle()
-            self.startRecordingButton.isEnabled.toggle()
-        }
+        self.stopRecordingButton.isEnabled.toggle()
+        self.startRecordingButton.isEnabled.toggle()
     }
 }
 
@@ -155,16 +142,12 @@ extension TFLiteViewController: SpeechEventListener, PipelineDelegate {
     
     func didStart() {
         print("didStart")
-        DispatchQueue.main.async {
-            self.toggleStartStop()
-        }
+        self.toggleStartStop()
     }
     
     func didStop() {
         print("didStart")
-        DispatchQueue.main.async {
-            self.toggleStartStop()
-        }
+        self.toggleStartStop()
     }
     
     func didTrace(_ trace: String) {

--- a/SpokestackFrameworkExample/TFLiteViewController.swift
+++ b/SpokestackFrameworkExample/TFLiteViewController.swift
@@ -155,12 +155,16 @@ extension TFLiteViewController: SpeechEventListener, PipelineDelegate {
     
     func didStart() {
         print("didStart")
-        self.toggleStartStop()
+        DispatchQueue.main.async {
+            self.toggleStartStop()
+        }
     }
     
     func didStop() {
         print("didStart")
-        self.toggleStartStop()
+        DispatchQueue.main.async {
+            self.toggleStartStop()
+        }
     }
     
     func didTrace(_ trace: String) {

--- a/SpokestackTests/AppleSpeechRecognizerTest.swift
+++ b/SpokestackTests/AppleSpeechRecognizerTest.swift
@@ -14,8 +14,7 @@ import AVFoundation
 class AppleSpeechRecognizerTest: XCTestCase {
 
     /// startStreaming
-    func testStartStreaming() {
-        
+    func testStartStopStreaming() {
         let delegate = AppleSpeechRecognizerTestDelegate()
         let asr = AppleSpeechRecognizer.sharedInstance
         let context = SpeechContext()
@@ -23,15 +22,9 @@ class AppleSpeechRecognizerTest: XCTestCase {
         asr.delegate = delegate
         asr.startStreaming(context: context)
         XCTAssert(context.isActive)
-        
-//        XCTAssertNoThrow(try AVAudioSession.sharedInstance().setCategory(.ambient))
-//        asr.startStreaming(context: context)
-//        while(!delegate.didRecognize) { // asr is running in background, which is not allowed.
-//            print("waiting for speech input")
-//        }
+        asr.stopStreaming(context: context)
+        XCTAssert(!context.isActive)
     }
-    
-    /// stopStreaming
 }
 
 class AppleSpeechRecognizerTestDelegate: PipelineDelegate, SpeechEventListener {

--- a/SpokestackTests/AudioControllerTest.swift
+++ b/SpokestackTests/AudioControllerTest.swift
@@ -15,40 +15,47 @@ class AudioControllerTest: XCTestCase {
     func testStreaming() {
         let controller = AudioController.sharedInstance
         let delegate = AudioControllerTestDelegate()
+        let context = SpeechContext()
         let setupFailedExpectation = expectation(description: "testStartStreaming calls AudioControllerTestDelegate as the result of setupFailed method completion")
         let processFrameExpectation = expectation(description: "testStartStreaming calls AudioControllerTestDelegate as the result of processFrame method completion")
 
-        /// Uninititalized delegates do not cause an exception during startStreaming
-        XCTAssertNoThrow(controller.startStreaming(context: SpeechContext()))
+        // Uninititalized delegates do not cause an exception during startStreaming
+        XCTAssertNoThrow(controller.startStreaming(context: context))
+        /// stopStreaming does not cause an exception
+        XCTAssertNoThrow(controller.stopStreaming(context: context))
         
-        /// Initialized PipelineDelegate is called during startStreaming
+        // Initialized PipelineDelegate is called during startStreaming
         controller.pipelineDelegate = delegate
         controller.delegate = delegate
         delegate.asyncExpectation = setupFailedExpectation
         XCTAssertNoThrow(try AVAudioSession.sharedInstance().setCategory(.ambient))
-        XCTAssertNoThrow(controller.startStreaming(context: SpeechContext()))
+        XCTAssertNoThrow(controller.startStreaming(context: context))
         wait(for: [setupFailedExpectation], timeout: 1)
         XCTAssert(delegate.didSetupFailed)
-        delegate.reset()
-        
         /// stopStreaming does not cause an exception
-        XCTAssertNoThrow(controller.stopStreaming(context: SpeechContext()))
-        
-        /// AudioControllerDelegate processFrame is called
+        XCTAssertNoThrow(controller.stopStreaming(context: context))
+
+        delegate.reset()
+
+        // AudioControllerDelegate processFrame is called
         XCTAssertNoThrow(try AVAudioSession.sharedInstance().setCategory(.record))
         delegate.asyncExpectation = processFrameExpectation
-        XCTAssertNoThrow(controller.startStreaming(context: SpeechContext()))
+        XCTAssertNotNil(controller.delegate)
+        XCTAssertNotNil(delegate.asyncExpectation)
+        XCTAssertNoThrow(controller.startStreaming(context: context))
         wait(for: [processFrameExpectation], timeout: 2)
         XCTAssert(delegate.didProcessFrame)
+        // stopStreaming does not cause an exception
+        XCTAssertNoThrow(controller.stopStreaming(context: context))
     }
 }
 
+/// Spy pattern for the system under test.
 class AudioControllerTestDelegate: AudioControllerDelegate, PipelineDelegate {
     
-    /// Spy pattern for the system under test.
-    /// asyncExpectation lets the caller's test know when the delegate has been called.
     var didProcessFrame: Bool = false
     var didSetupFailed: Bool = false
+    /// asyncExpectation lets the caller's test know when the delegate has been called.
     var asyncExpectation: XCTestExpectation?
     
     func reset() {
@@ -56,13 +63,21 @@ class AudioControllerTestDelegate: AudioControllerDelegate, PipelineDelegate {
         asyncExpectation = .none
     }
     
-    func process(_ frame: Data) {
-        guard let _ = asyncExpectation else {
-            XCTFail("AudioControllerTestDelegate was not setup correctly. Missing XCTExpectation reference")
-            return
+    func process(_ frame: Data) -> Void {
+        audioProcessingQueue.async {[weak self] in
+            // NB the as? cast is necessary for integration testing
+            guard let strongSelf = self as? AudioControllerTestDelegate else {
+                XCTFail("AudioControllerTestDelegate was not setup correctly. Missing strong self reference")
+                return
+            }
+            guard let ae = strongSelf.asyncExpectation else {
+                XCTFail("AudioControllerTestDelegate was not setup correctly. Missing XCTExpectation reference")
+                return
+            }
+            strongSelf.didProcessFrame = true
+            ae.fulfill()
+            strongSelf.asyncExpectation = nil
         }
-        self.didProcessFrame = true
-        self.asyncExpectation?.fulfill()
     }
     
     func didInit() {
@@ -78,12 +93,13 @@ class AudioControllerTestDelegate: AudioControllerDelegate, PipelineDelegate {
     }
     
     func setupFailed(_ error: String) {
-        guard let _ = asyncExpectation else {
+        guard let ae = self.asyncExpectation else {
             XCTFail("AudioControllerTestDelegate was not setup correctly. Missing XCTExpectation reference")
             return
         }
         self.didSetupFailed = true
-        self.asyncExpectation?.fulfill()
+        ae.fulfill()
+        self.asyncExpectation = nil
     }
     
     func didTrace(_ trace: String) {

--- a/SpokestackTests/SharedTestMocks.swift
+++ b/SpokestackTests/SharedTestMocks.swift
@@ -97,7 +97,7 @@ internal struct SharedTestMocks {
     [UNK]
     alesund
     """
-        let file = FileManager.default.createFile(atPath: path, contents: vocab.data(using: .utf8), attributes: .none)
+        let _ = FileManager.default.createFile(atPath: path, contents: vocab.data(using: .utf8), attributes: .none)
         return path
         
     }

--- a/SpokestackTests/SpeechPipelineTest.swift
+++ b/SpokestackTests/SpeechPipelineTest.swift
@@ -18,7 +18,7 @@ class SpeechPipelineTest: XCTestCase {
         let didInitExpectation = expectation(description: "testInit calls SpeechPipelineTestDelegate as the result of didInit method completion")
         delegate.asyncExpectation = didInitExpectation
 
-        /// successful init calls didInit
+        // successful init calls didInit
         _ = SpeechPipeline(delegate, pipelineDelegate: delegate)
         wait(for: [didInitExpectation], timeout: 1)
         XCTAssert(delegate.didDidInit)
@@ -32,12 +32,12 @@ class SpeechPipelineTest: XCTestCase {
         let config = SpeechConfiguration()
         config.fftHopLength = 30
 
-        /// successful init calls didInit
+        // successful init calls didInit
         let p = SpeechPipeline(TestProcessor(true), speechConfiguration: config, speechDelegate: delegate, wakewordService: TestProcessor(), pipelineDelegate: delegate)
         wait(for: [didInitExpectation], timeout: 1)
         XCTAssert(delegate.didDidInit)
         
-        /// successful init sets config property
+        // successful init sets config property
         XCTAssert(p.speechConfiguration?.fftHopLength == 30)
     }
     
@@ -46,7 +46,7 @@ class SpeechPipelineTest: XCTestCase {
         var delegate: SpeechPipelineTestDelegate
         let didInitExpectation = expectation(description: "testStatus calls SpeechPipelineTestDelegate as the result of didInit method completion")
         
-        /// ensure that the pipeline retains a reference to the delegate
+        // ensure that the pipeline retains a reference to the delegate
         delegate = SpeechPipelineTestDelegate()
         delegate.asyncExpectation = didInitExpectation
         let p = SpeechPipeline(TestProcessor(true), speechConfiguration: SpeechConfiguration(), speechDelegate: delegate, wakewordService: TestProcessor(), pipelineDelegate: delegate)
@@ -63,18 +63,18 @@ class SpeechPipelineTest: XCTestCase {
         let didInitExpectation = expectation(description: "didInitExpectation fulfills when testSetDelegates calls SpeechPipelineTestDelegate as the result of didInit method completion")
         let activateExpectation = expectation(description: "activateExpectation fulfills when testSetDelegates calls SpeechPipelineTestDelegate as the result of activate method completion")
         
-        /// init the pipeline
+        // init the pipeline
         delegate = SpeechPipelineTestDelegate()
         delegate.asyncExpectation = didInitExpectation
         let p = SpeechPipeline(TestProcessor(true), speechConfiguration: SpeechConfiguration(), speechDelegate: delegate, wakewordService: TestProcessor(), pipelineDelegate: delegate)
         wait(for: [didInitExpectation], timeout: 1)
         
-        /// change the pipeline's delegates
+        // change the pipeline's delegates
         delegate = SpeechPipelineTestDelegate()
         delegate.asyncExpectation = activateExpectation
         p.setDelegates(delegate, pipelineDelegate: delegate)
         
-        /// assert that the pipeline's delegate references (and pipeline's service delegates) have changed
+        // assert that the pipeline's delegate references (and pipeline's service delegates) have changed
         XCTAssert(delegate === p.speechDelegate)
         p.speechDelegate?.activate()
         wait(for: [activateExpectation], timeout: 1)
@@ -88,11 +88,11 @@ class SpeechPipelineTest: XCTestCase {
         delegate.asyncExpectation = didInitExpectation
         let config = SpeechConfiguration()
 
-        /// init the pipeline
+        // init the pipeline
         let p = SpeechPipeline(TestProcessor(true), speechConfiguration: config, speechDelegate: delegate, wakewordService: TestProcessor(), pipelineDelegate: delegate)
         wait(for: [didInitExpectation], timeout: 1)
         
-        /// activate and deactivate the pipeline
+        // activate and deactivate the pipeline
         p.activate()
         XCTAssert(p.context.isActive)
         p.deactivate()
@@ -107,7 +107,7 @@ class SpeechPipelineTest: XCTestCase {
         let delegate = SpeechPipelineTestDelegate()
         let context = SpeechConfiguration()
 
-        /// init the pipeline
+        // init the pipeline
         delegate.asyncExpectation = didInitExpectation
         let p = SpeechPipeline(TestProcessor(true), speechConfiguration: context, speechDelegate: delegate, wakewordService: TestProcessor(), pipelineDelegate: delegate)
         wait(for: [didInitExpectation], timeout: 1)
@@ -131,12 +131,12 @@ class SpeechPipelineTest: XCTestCase {
         let delegate = SpeechPipelineTestDelegate()
         let context = SpeechConfiguration()
         
-        /// init the pipeline
+        // init the pipeline
         delegate.asyncExpectation = didInitExpectation
         let p = SpeechPipeline(SpeechProcessors.appleSpeech.processor, speechConfiguration: context, speechDelegate: delegate, wakewordService: SpeechProcessors.appleWakeword.processor, pipelineDelegate: delegate)
         wait(for: [didInitExpectation], timeout: 1)
         
-        /// start and stop the pipeline
+        // start and stop the pipeline
         delegate.asyncExpectation = didStartExpectation
         p.start()
         wait(for: [didStartExpectation], timeout: 1)
@@ -144,6 +144,7 @@ class SpeechPipelineTest: XCTestCase {
         delegate.asyncExpectation = didStopExpectation
         p.stop()
         wait(for: [didStopExpectation], timeout: 1)
+        sleep(5)
         XCTAssert(!p.context.isActive)
     }
 }
@@ -177,6 +178,7 @@ class SpeechPipelineTestDelegate: PipelineDelegate, SpeechEventListener {
         }
         self.didActivate = true
         self.asyncExpectation?.fulfill()
+        self.asyncExpectation = nil
     }
     
     func didInit() {
@@ -186,6 +188,7 @@ class SpeechPipelineTestDelegate: PipelineDelegate, SpeechEventListener {
         }
         self.didDidInit = true
         self.asyncExpectation?.fulfill()
+        self.asyncExpectation = nil
     }
     
     func didStart() {
@@ -195,6 +198,7 @@ class SpeechPipelineTestDelegate: PipelineDelegate, SpeechEventListener {
         }
         self.didDidStart = true
         self.asyncExpectation?.fulfill()
+        self.asyncExpectation = nil
     }
     
     func didStop() {
@@ -204,6 +208,7 @@ class SpeechPipelineTestDelegate: PipelineDelegate, SpeechEventListener {
         }
         self.didDidStop = true
         self.asyncExpectation?.fulfill()
+        self.asyncExpectation = nil
     }
     
     func setupFailed(_ error: String) {}

--- a/SpokestackTests/TextToSpeechTest.swift
+++ b/SpokestackTests/TextToSpeechTest.swift
@@ -79,7 +79,7 @@ class TextToSpeechTest: XCTestCase {
                     XCTAssertNotNil(result.first?.url)
             })
         XCTAssertNotNil(publisher)
-        wait(for: [didCompleteExpectation], timeout: 10)
+        wait(for: [didCompleteExpectation], timeout: 5)
     }
     
     /// MARK:  Speak

--- a/SpokestackTests/WebRTCVADTest.swift
+++ b/SpokestackTests/WebRTCVADTest.swift
@@ -78,6 +78,11 @@ class WebRTCVADTestDelegate: VADDelegate, PipelineDelegate {
     var didActivate: Bool = false
     var didDeactivate: Bool = false
     var asyncExpectation: XCTestExpectation?
+    var config = SpeechConfiguration()
+    
+    init() {
+        config.tracing = .DEBUG
+    }
     
     func reset() {
         didActivate = false
@@ -86,19 +91,19 @@ class WebRTCVADTestDelegate: VADDelegate, PipelineDelegate {
     }
     
     func didInit() {
-        Trace.trace(Trace.Level.DEBUG, configLevel: Trace.Level.DEBUG, message: "didInit", delegate: self, caller: self)
+        Trace.trace(Trace.Level.DEBUG, config: self.config, message: "didInit", delegate: self, caller: self)
     }
     
     func didStart() {
-        Trace.trace(Trace.Level.DEBUG, configLevel: Trace.Level.DEBUG, message: "didStart", delegate: self, caller: self)
+        Trace.trace(Trace.Level.DEBUG, config: self.config, message: "didStart", delegate: self, caller: self)
     }
     
     func didStop() {
-        Trace.trace(Trace.Level.DEBUG, configLevel: Trace.Level.DEBUG, message: "didStop", delegate: self, caller: self)
+        Trace.trace(Trace.Level.DEBUG, config: self.config, message: "didStop", delegate: self, caller: self)
     }
     
     func setupFailed(_ error: String) {
-        Trace.trace(Trace.Level.DEBUG, configLevel: Trace.Level.DEBUG, message: "setupFailed", delegate: self, caller: self)
+        Trace.trace(Trace.Level.DEBUG, config: self.config, message: "setupFailed", delegate: self, caller: self)
     }
     
     func didTrace(_ trace: String) {
@@ -111,7 +116,7 @@ class WebRTCVADTestDelegate: VADDelegate, PipelineDelegate {
             return
         }
         self.didActivate = true
-        Trace.trace(Trace.Level.DEBUG, configLevel: Trace.Level.DEBUG, message: "activate", delegate: self, caller: self)
+        Trace.trace(Trace.Level.DEBUG, config: self.config, message: "activate", delegate: self, caller: self)
         asyncExpectation?.fulfill()
     }
     
@@ -121,7 +126,7 @@ class WebRTCVADTestDelegate: VADDelegate, PipelineDelegate {
             return
         }
         self.didDeactivate = true
-        Trace.trace(Trace.Level.DEBUG, configLevel: Trace.Level.DEBUG, message: "deactivate", delegate: self, caller: self)
+        Trace.trace(Trace.Level.DEBUG, config: self.config, message: "deactivate", delegate: self, caller: self)
         asyncExpectation?.fulfill()
     }
 }


### PR DESCRIPTION
Adds a new `delegateDispatchQueue` configuration (defaulted to a non-UI-thread queue with high quality of service) so that clients can specify what dispatch queue to receive all delegate events on. Apple's [URLSession](https://developer.apple.com/documentation/foundation/urlsession/1411571-delegatequeue) provides an example of this pattern.

Associated work is configuring all delegate events to be sent over the configured queue, and fixing some nagging concurrency problems in both code and tests. Also included are updates to the README and API docs.

This will represent a breaking version since a client delegate implementation was previously called on a UI thread and thus safely perform UI work inside that context.