### PR TITLE
fixed bug in nlu slot selset with pre/post-pended punctuation

### DIFF
--- a/Spokestack/NLUTensorflow.swift
+++ b/Spokestack/NLUTensorflow.swift
@@ -193,7 +193,7 @@ import TensorFlowLite
         }
         var intent = metadata.model.intents[intentsArgmax.0]
         intent.confidence = intentsArgmax.1
-        Trace.trace(Trace.Level.DEBUG, config: self.configuration, message: "classify intent: \(intent)", delegate: self.delegate, caller: self)
+        Trace.trace(Trace.Level.DEBUG, config: self.configuration, message: "classify intent: \(intent.name)", delegate: self.delegate, caller: self)
         return intent
     }
     

--- a/Spokestack/NLUTensorflowSlotParsers.swift
+++ b/Spokestack/NLUTensorflowSlotParsers.swift
@@ -52,7 +52,9 @@ internal struct NLUTensorflowSlotParser {
             guard let parsed = try slot.parsed() as? NLUTensorflowSelset else {
                 throw NLUError.metadata("The NLU metadata for the \(slot.name) slot was not found.")
             }
-            let decoded = try encoder.decodeWithWhitespace(encodedTokens: encodedTokens, whitespaceIndices: whitespaceIndices)
+            let decoded = try encoder
+                .decodeWithWhitespace(encodedTokens: encodedTokens, whitespaceIndices: whitespaceIndices)
+                .trimmingCharacters(in: .punctuationCharacters)
             let contains = parsed.selections.filter { selection in
                 selection.name == decoded || selection.aliases.contains(decoded)
             }

--- a/SpokestackTests/NLUTensorflowSlotParserTest.swift
+++ b/SpokestackTests/NLUTensorflowSlotParserTest.swift
@@ -29,6 +29,11 @@ class NLUTensorflowSlotParserTest: XCTestCase {
         let et = EncodedTokens(tokensByWhitespace: ["kitchen"], encodedTokensByWhitespaceIndex: [0], encoded: [0])
         let parsedSelset = try! parser.parse(tags: ["b_location"], intent: metadata!.intents.filter({ $0.name == "request.lights.deactivate" }).first!, encoder: encoder!, encodedTokens: et)
         XCTAssertEqual(parsedSelset!["location"]!.value as! String, "room")
+        
+        // selset value has appended punctuation
+        let et2 = EncodedTokens(tokensByWhitespace: ["kitchen."], encodedTokensByWhitespaceIndex: [0], encoded: [0,1])
+        let parsedSelset2 = try! parser.parse(tags: ["b_location"], intent: metadata!.intents.filter({ $0.name == "request.lights.deactivate" }).first!, encoder: encoder!, encodedTokens: et2)
+        XCTAssertEqual(parsedSelset2!["location"]!.value as! String, "room")
     }
     
     func testParseInteger() {


### PR DESCRIPTION
An nlu sentence like `Turn the lights on in the kitchen.` would not result in a slot value for `kitchen` due to the `.`. This fixes that bug.