### PR TITLE
API Change: TTS input voice is now a String (+ improved TTS errors)

### DIFF
--- a/Spokestack/Error.swift
+++ b/Spokestack/Error.swift
@@ -62,10 +62,12 @@ enum TextToSpeechErrors: Error {
     case apiKey(String)
     /// The speak command could not be executed.
     case speak(String)
-    /// The input format was not specified correctly
+    /// The input format was not specified correctly.
     case format(String)
-    /// The input voice was not specified correctly
+    /// The input voice was not specified correctly.
     case voice(String)
+    /// The HTTP reponse status code was not OK.
+    case httpStatusCode(String)
 }
 
 /// Errors thrown by a Tokenizer instance.

--- a/Spokestack/TextToSpeech.swift
+++ b/Spokestack/TextToSpeech.swift
@@ -301,7 +301,7 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
         }
         let body = try self.decoder.decode(TTSTResponse.self, from: data)
         if let e = body.errors {
-            let message = e.map { $0.message }.joined("; ")
+            let message = e.map { $0.message }.joined(separator: " ")
             throw TextToSpeechErrors.format(message)
         }
         guard let data = body.data else
@@ -309,18 +309,14 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
             throw TextToSpeechErrors.deserialization("Could not deserialize the response.")
         }
         
-        switch inputFormat {
-        // NB the input format switch guarantees safe access to the synthesisFormat url.
-        case .ssml:
-            let result = TextToSpeechResult(id: id, url: data.synthesizeSsml!.url)
-            return result
-        case .markdown:
-            let result = TextToSpeechResult(id: id, url: data.synthesizeMarkdown!.url)
-            return result
-        case .text:
-            let result = TextToSpeechResult(id: id, url: data.synthesizeText!.url)
-            return result
-        }
+        var url: URL { switch inputFormat {
+        // NB the inputFormat switch guarantees safe access to the synthesisFormat url.
+        case .ssml: return data.synthesizeSsml!.url
+        case .markdown: return data.synthesizeMarkdown!.url
+        case .text: return data.synthesizeText!.url
+        }}
+        let result = TextToSpeechResult(id: id, url: url)
+        return result
     }
     
     /// Internal function that must be public for Objective-C compatibility reasons.

--- a/Spokestack/TextToSpeech.swift
+++ b/Spokestack/TextToSpeech.swift
@@ -42,7 +42,6 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
     private var configuration: SpeechConfiguration
     private lazy var player: AVPlayer = AVPlayer()
     private var apiKey: SymmetricKey?
-    private let ttsInputVoices = [0: "demo-male"]
     private let decoder = JSONDecoder()
     
     // MARK: Initializers
@@ -239,17 +238,13 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
         request.addValue(input.id, forHTTPHeaderField: "x-request-id")
         request.httpMethod = "POST"
         var body: [String:Any] = [:]
-        // necessary check due to objc interop with enum
-        guard let _ = TTSInputVoice.init(rawValue: input.voice.rawValue) else {
-            throw TextToSpeechErrors.voice("The input voice must be specified.")
-        }
         switch input.inputFormat {
         case .ssml:
             body = [
                 "query":"query iOSSynthesisSSML($voice: String!, $ssml: String!) {synthesizeSsml(voice: $voice, ssml: $ssml) {url}}",
                 "variables":[
-                    "voice":self.ttsInputVoices[input.voice.rawValue],
-                    "ssml":input.input
+                    "voice": input.voice,
+                    "ssml": input.input
                 ]
             ]
             break
@@ -257,8 +252,8 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
             body = [
                 "query":"query iOSSynthesisMarkdown($voice: String!, $markdown: String!) {synthesizeMarkdown(voice: $voice, markdown: $markdown) {url}}",
                 "variables":[
-                    "voice":self.ttsInputVoices[input.voice.rawValue],
-                    "markdown":input.input
+                    "voice": input.voice,
+                    "markdown": input.input
                 ]
             ]
             break
@@ -266,8 +261,8 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
             body = [
                 "query":"query iOSSynthesisText($voice: String!, $text: String!) {synthesizeText(voice: $voice, text: $text) {url}}",
                 "variables":[
-                    "voice":self.ttsInputVoices[input.voice.rawValue],
-                    "text":input.input
+                    "voice": input.voice,
+                    "text": input.input
                 ]
             ]
             break

--- a/Spokestack/TextToSpeech.swift
+++ b/Spokestack/TextToSpeech.swift
@@ -153,7 +153,7 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
                                     throw TextToSpeechErrors.deserialization("Response is not a valid HTTPURLResponse")
                                 }
                                 if httpResponse.statusCode != 200 {
-                                    throw TextToSpeechErrors.httpStatusCode("The  response status code was \(httpResponse.statusCode), cannot process response.")
+                                    throw TextToSpeechErrors.httpStatusCode("The HTTP status was \(httpResponse.statusCode); cannot process response.")
                                 }
                                 do {
                                     let result = try self.createSynthesizeResponse(data: data, response: httpResponse, inputFormat: input.inputFormat)
@@ -210,7 +210,7 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
                         }
                         if httpResponse.statusCode != 200 {
                             self.configuration.delegateDispatchQueue.async {
-                            self.delegate?.failure(ttsError: TextToSpeechErrors.httpStatusCode("The  response status code was \(httpResponse.statusCode), cannot process response."))
+                            self.delegate?.failure(ttsError: TextToSpeechErrors.httpStatusCode("The HTTP status was \(httpResponse.statusCode); cannot process response."))
                             }
                             return
                         }
@@ -301,9 +301,7 @@ private let apiQueue = DispatchQueue(label: TTSSpeechQueueName, qos: .userInitia
         }
         let body = try self.decoder.decode(TTSTResponse.self, from: data)
         if let e = body.errors {
-            let message = e.reduce("", { msg, error in
-                return msg + error.message + " "
-            })
+            let message = e.map { $0.message }.joined("; ")
             throw TextToSpeechErrors.format(message)
         }
         guard let data = body.data else

--- a/Spokestack/TextToSpeechInput.swift
+++ b/Spokestack/TextToSpeechInput.swift
@@ -18,10 +18,6 @@ import Foundation
     case markdown
 }
 
-@objc public enum TTSInputVoice: Int {
-    case demoMale
-}
-
 /// Input parameters for speech synthesis. Parameters are considered transient and may change each time `synthesize` is called.
 /// - SeeAlso: `TextToSpeech.synthesize`
 @objc public class TextToSpeechInput: NSObject {
@@ -32,7 +28,7 @@ import Foundation
     /// - Parameter inputFormat: The formatting of the input.
     /// - Parameter id: A unique identifier for this input request.
     @objc public init(_ input:String = "Here I am, a brain the size of a planet.",
-                      voice: TTSInputVoice = .demoMale,
+                      voice: String = "demo-male",
                       inputFormat: TTSInputFormat = .text,
                       id: String = UUID().description) {
         self.input = input
@@ -43,7 +39,7 @@ import Foundation
     }
     
     /// The synthetic voice used to generate speech.
-    @objc public var voice: TTSInputVoice
+    @objc public var voice: String
     /// The input to the synthetic voice.
     /// - Note: SSML must be valid XML.
     @objc public var input: String

--- a/SpokestackTests/TextToSpeechTest.swift
+++ b/SpokestackTests/TextToSpeechTest.swift
@@ -32,6 +32,17 @@ class TextToSpeechTest: XCTestCase {
         let config = SpeechConfiguration()
         let tts = TextToSpeech(delegate, configuration: config)
         
+        // bad input results in a failed request that calls failure
+        delegate.reset()
+        let didFailInputExpectation = expectation(description: "bad input results in a failed request that calls failure")
+        delegate.asyncExpectation = didFailInputExpectation
+        let badInput = TextToSpeechInput()
+        badInput.voice = "tracy-throne"
+        tts.synthesize(badInput)
+        wait(for: [didFailInputExpectation], timeout: 5)
+        XCTAssert(delegate.didFail)
+        XCTAssertFalse(delegate.didSucceed)
+        
         // successful request calls success
         delegate.reset()
         let didSucceedExpectation = expectation(description: "successful request calls TestTextToSpeechDelegate.success")

--- a/SpokestackTests/TextToSpeechTest.swift
+++ b/SpokestackTests/TextToSpeechTest.swift
@@ -50,7 +50,7 @@ class TextToSpeechTest: XCTestCase {
         // successful request with ssml formatting
         let didSucceedExpectation2 = expectation(description: "successful request calls TestTextToSpeechDelegate.success")
         delegate.asyncExpectation = didSucceedExpectation2
-        let ssmlInput = TextToSpeechInput("<speak>Yet right now the average age of this 52nd Parliament is 49 years old, <break time='500ms'/> OK Boomer.</speak>", voice: .demoMale, inputFormat: .ssml)
+        let ssmlInput = TextToSpeechInput("<speak>Yet right now the average age of this 52nd Parliament is 49 years old, <break time='500ms'/> OK Boomer.</speak>", voice: "demo-male", inputFormat: .ssml)
         tts.synthesize(ssmlInput)
         wait(for: [didSucceedExpectation2], timeout: 5)
         XCTAssert(delegate.didSucceed)
@@ -66,7 +66,7 @@ class TextToSpeechTest: XCTestCase {
         delegate.reset()
         let didSucceedExpectation3 = expectation(description: "successful request calls TestTextToSpeechDelegate.success")
         delegate.asyncExpectation = didSucceedExpectation3
-        let markdownInput = TextToSpeechInput("Yet right now the average age of this (50)[number] second Parliament is (49)[number] years old, [1s] OK Boomer.", voice: .demoMale, inputFormat: .markdown)
+        let markdownInput = TextToSpeechInput("Yet right now the average age of this (50)[number] second Parliament is (49)[number] years old, [1s] OK Boomer.", voice: "demo-male", inputFormat: .markdown)
         tts.synthesize(markdownInput)
         wait(for: [didSucceedExpectation3], timeout: 5)
         XCTAssert(delegate.didSucceed)


### PR DESCRIPTION
To provide Spokestack account flexibility and to match spokestack-android, `TTSInputVoice` enum has been deprecated. Now a caller may pass in a `String` id for a voice. A default value is still provided, `demo-male`.

Also, GraphQL errors are now passed to the client in the error message, and things that aren't deserialization errors are not called deserialization errors.