### PR TITLE
Tensorflow integration testing

### DIFF
--- a/Spokestack.xcodeproj/project.pbxproj
+++ b/Spokestack.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		59A8DBF92384ABF000F97700 /* TextToSpeechTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A8DBF82384ABF000F97700 /* TextToSpeechTest.swift */; };
 		59A8DBFA2384AC0100F97700 /* TextToSpeech.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596B82472384A097004BAEF4 /* TextToSpeech.swift */; };
 		59A8DBFB2384AC0500F97700 /* TextToSpeechInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596567802384AA1100CFCE23 /* TextToSpeechInput.swift */; };
+		59AA893D2472EE5500197D7A /* NLUTensorflowTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AA893C2472EE5500197D7A /* NLUTensorflowTest.swift */; };
 		59C15D53234D322A00B091F4 /* WebRTCVAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C15D52234D322A00B091F4 /* WebRTCVAD.swift */; };
 		59C2AFDA2319CB7100E47AC5 /* RingBufferTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C2AFD92319CB7100E47AC5 /* RingBufferTest.swift */; };
 		59C2AFDB2319CE5800E47AC5 /* SpeechConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A0D5C52204E8E4003709C3 /* SpeechConfiguration.swift */; };
@@ -85,6 +86,7 @@
 		59C2AFE92319CF4100E47AC5 /* SignalProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E0E13422FE2C2B0060F012 /* SignalProcessing.swift */; };
 		59C2AFEA2319CF8A00E47AC5 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FB0C8A22AEE4F100FB9662 /* Data+Extensions.swift */; };
 		59C2AFEE231ED07100E47AC5 /* WebRTCVADTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C2AFED231ED07100E47AC5 /* WebRTCVADTest.swift */; };
+		59D3685D247714DF0052F483 /* mock_nlu.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 59D3685C247714DF0052F483 /* mock_nlu.tflite */; };
 		59D78F5F2322D13700728A98 /* AudioControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D78F5E2322D13700728A98 /* AudioControllerTest.swift */; };
 		59D78F612322EAE000728A98 /* SpeechPipelineTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D78F602322EAE000728A98 /* SpeechPipelineTest.swift */; };
 		59E0E13522FE2C2B0060F012 /* SignalProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E0E13422FE2C2B0060F012 /* SignalProcessing.swift */; };
@@ -207,9 +209,11 @@
 		59A0D5C52204E8E4003709C3 /* SpeechConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpeechConfiguration.swift; sourceTree = "<group>"; };
 		59A45E4E2243ED530089D023 /* PipelineDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipelineDelegate.swift; sourceTree = "<group>"; };
 		59A8DBF82384ABF000F97700 /* TextToSpeechTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextToSpeechTest.swift; sourceTree = "<group>"; };
+		59AA893C2472EE5500197D7A /* NLUTensorflowTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NLUTensorflowTest.swift; sourceTree = "<group>"; };
 		59C15D52234D322A00B091F4 /* WebRTCVAD.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebRTCVAD.swift; path = Spokestack/WebRTCVAD.swift; sourceTree = SOURCE_ROOT; };
 		59C2AFD92319CB7100E47AC5 /* RingBufferTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingBufferTest.swift; sourceTree = "<group>"; };
 		59C2AFED231ED07100E47AC5 /* WebRTCVADTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCVADTest.swift; sourceTree = "<group>"; };
+		59D3685C247714DF0052F483 /* mock_nlu.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; name = mock_nlu.tflite; path = ../../../Downloads/mock_nlu.tflite; sourceTree = "<group>"; };
 		59D78F5E2322D13700728A98 /* AudioControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioControllerTest.swift; sourceTree = "<group>"; };
 		59D78F602322EAE000728A98 /* SpeechPipelineTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechPipelineTest.swift; sourceTree = "<group>"; };
 		59E0E13422FE2C2B0060F012 /* SignalProcessing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalProcessing.swift; sourceTree = "<group>"; };
@@ -336,6 +340,7 @@
 		01D31F48216BAF260055FD45 /* SpokestackTests */ = {
 			isa = PBXGroup;
 			children = (
+				59D3685C247714DF0052F483 /* mock_nlu.tflite */,
 				59A8DBF82384ABF000F97700 /* TextToSpeechTest.swift */,
 				59C2AFD92319CB7100E47AC5 /* RingBufferTest.swift */,
 				59D78F5E2322D13700728A98 /* AudioControllerTest.swift */,
@@ -348,6 +353,7 @@
 				59E8959A23DB7A0B00C424D3 /* NLUTensorflowTokenizerTest.swift */,
 				5917AC4E2405C86300CB4900 /* NLUTensorflowSlotParserTest.swift */,
 				5917AC502405C89A00CB4900 /* SharedTestMocks.swift */,
+				59AA893C2472EE5500197D7A /* NLUTensorflowTest.swift */,
 			);
 			path = SpokestackTests;
 			sourceTree = "<group>";
@@ -674,6 +680,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				59D3685D247714DF0052F483 /* mock_nlu.tflite in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -832,6 +839,7 @@
 				5917AC4F2405C86300CB4900 /* NLUTensorflowSlotParserTest.swift in Sources */,
 				59ECA8C823C939AA003CDB57 /* TextToSpeechResult.swift in Sources */,
 				597D0CAE23F716AF00018D71 /* NLUService.swift in Sources */,
+				59AA893D2472EE5500197D7A /* NLUTensorflowTest.swift in Sources */,
 				5942C4362384772600EC0B13 /* TextToSpeechDelegate.swift in Sources */,
 				59A8DBF92384ABF000F97700 /* TextToSpeechTest.swift in Sources */,
 				59C2AFE82319CF3900E47AC5 /* FFT.swift in Sources */,

--- a/Spokestack.xcodeproj/project.pbxproj
+++ b/Spokestack.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		59A8DBFA2384AC0100F97700 /* TextToSpeech.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596B82472384A097004BAEF4 /* TextToSpeech.swift */; };
 		59A8DBFB2384AC0500F97700 /* TextToSpeechInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596567802384AA1100CFCE23 /* TextToSpeechInput.swift */; };
 		59AA893D2472EE5500197D7A /* NLUTensorflowTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AA893C2472EE5500197D7A /* NLUTensorflowTest.swift */; };
+		59AB0B0724786B69007B7582 /* TFLiteWakewordRecognizerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AB0B0624786B69007B7582 /* TFLiteWakewordRecognizerTest.swift */; };
 		59C15D53234D322A00B091F4 /* WebRTCVAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C15D52234D322A00B091F4 /* WebRTCVAD.swift */; };
 		59C2AFDA2319CB7100E47AC5 /* RingBufferTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C2AFD92319CB7100E47AC5 /* RingBufferTest.swift */; };
 		59C2AFDB2319CE5800E47AC5 /* SpeechConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A0D5C52204E8E4003709C3 /* SpeechConfiguration.swift */; };
@@ -86,7 +87,6 @@
 		59C2AFE92319CF4100E47AC5 /* SignalProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E0E13422FE2C2B0060F012 /* SignalProcessing.swift */; };
 		59C2AFEA2319CF8A00E47AC5 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FB0C8A22AEE4F100FB9662 /* Data+Extensions.swift */; };
 		59C2AFEE231ED07100E47AC5 /* WebRTCVADTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C2AFED231ED07100E47AC5 /* WebRTCVADTest.swift */; };
-		59D3685D247714DF0052F483 /* mock_nlu.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 59D3685C247714DF0052F483 /* mock_nlu.tflite */; };
 		59D78F5F2322D13700728A98 /* AudioControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D78F5E2322D13700728A98 /* AudioControllerTest.swift */; };
 		59D78F612322EAE000728A98 /* SpeechPipelineTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D78F602322EAE000728A98 /* SpeechPipelineTest.swift */; };
 		59E0E13522FE2C2B0060F012 /* SignalProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E0E13422FE2C2B0060F012 /* SignalProcessing.swift */; };
@@ -110,6 +110,10 @@
 		59FB0C8B22AEE4F100FB9662 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FB0C8A22AEE4F100FB9662 /* Data+Extensions.swift */; };
 		59FB0C8D22B0640700FB9662 /* RingBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FB0C8C22B0640700FB9662 /* RingBuffer.swift */; };
 		59FB0C8F22B0682900FB9662 /* FFT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FB0C8E22B0682900FB9662 /* FFT.swift */; };
+		59FE4A902480580900976825 /* mock_nlu.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 59FE4A8C2480580900976825 /* mock_nlu.tflite */; };
+		59FE4A912480580900976825 /* mock_encoder.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 59FE4A8D2480580900976825 /* mock_encoder.tflite */; };
+		59FE4A9324805EA300976825 /* mock_filter.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 59FE4A9224805EA300976825 /* mock_filter.tflite */; };
+		59FE4A9724805F5F00976825 /* mock_detector.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 59FE4A9624805F5F00976825 /* mock_detector.tflite */; };
 		6B218E8C6733C09829E0EC8D /* Pods_Spokestack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC9D7D743DEFEF26F6187374 /* Pods_Spokestack.framework */; };
 		7310E0D477A0B18484970757 /* Pods_SpokestackFrameworkExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2E5DAE627A148F64B7FFBCD0 /* Pods_SpokestackFrameworkExample.framework */; };
 		944CCC7036716C10EB5EF6EA /* Pods_SpokestackTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCCC4FA8F563F7B62E3D68EE /* Pods_SpokestackTests.framework */; };
@@ -210,10 +214,10 @@
 		59A45E4E2243ED530089D023 /* PipelineDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipelineDelegate.swift; sourceTree = "<group>"; };
 		59A8DBF82384ABF000F97700 /* TextToSpeechTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextToSpeechTest.swift; sourceTree = "<group>"; };
 		59AA893C2472EE5500197D7A /* NLUTensorflowTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NLUTensorflowTest.swift; sourceTree = "<group>"; };
+		59AB0B0624786B69007B7582 /* TFLiteWakewordRecognizerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TFLiteWakewordRecognizerTest.swift; sourceTree = "<group>"; };
 		59C15D52234D322A00B091F4 /* WebRTCVAD.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebRTCVAD.swift; path = Spokestack/WebRTCVAD.swift; sourceTree = SOURCE_ROOT; };
 		59C2AFD92319CB7100E47AC5 /* RingBufferTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingBufferTest.swift; sourceTree = "<group>"; };
 		59C2AFED231ED07100E47AC5 /* WebRTCVADTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCVADTest.swift; sourceTree = "<group>"; };
-		59D3685C247714DF0052F483 /* mock_nlu.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; name = mock_nlu.tflite; path = ../../../Downloads/mock_nlu.tflite; sourceTree = "<group>"; };
 		59D78F5E2322D13700728A98 /* AudioControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioControllerTest.swift; sourceTree = "<group>"; };
 		59D78F602322EAE000728A98 /* SpeechPipelineTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechPipelineTest.swift; sourceTree = "<group>"; };
 		59E0E13422FE2C2B0060F012 /* SignalProcessing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalProcessing.swift; sourceTree = "<group>"; };
@@ -233,6 +237,10 @@
 		59FB0C8A22AEE4F100FB9662 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
 		59FB0C8C22B0640700FB9662 /* RingBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingBuffer.swift; sourceTree = "<group>"; };
 		59FB0C8E22B0682900FB9662 /* FFT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFT.swift; sourceTree = "<group>"; };
+		59FE4A8C2480580900976825 /* mock_nlu.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = mock_nlu.tflite; sourceTree = "<group>"; };
+		59FE4A8D2480580900976825 /* mock_encoder.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = mock_encoder.tflite; sourceTree = "<group>"; };
+		59FE4A9224805EA300976825 /* mock_filter.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = mock_filter.tflite; sourceTree = "<group>"; };
+		59FE4A9624805F5F00976825 /* mock_detector.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = mock_detector.tflite; sourceTree = "<group>"; };
 		87E00C354EAE6F97CE48B5AE /* Pods-SpokestackFrameworkExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SpokestackFrameworkExample.release.xcconfig"; path = "Target Support Files/Pods-SpokestackFrameworkExample/Pods-SpokestackFrameworkExample.release.xcconfig"; sourceTree = "<group>"; };
 		9046EDB03884D7895DE41621 /* Pods-SpokestackFrameworkExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SpokestackFrameworkExample.debug.xcconfig"; path = "Target Support Files/Pods-SpokestackFrameworkExample/Pods-SpokestackFrameworkExample.debug.xcconfig"; sourceTree = "<group>"; };
 		C4C6D917748DF75FB3939507 /* Pods-Spokestack.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Spokestack.debug.xcconfig"; path = "Target Support Files/Pods-Spokestack/Pods-Spokestack.debug.xcconfig"; sourceTree = "<group>"; };
@@ -340,7 +348,10 @@
 		01D31F48216BAF260055FD45 /* SpokestackTests */ = {
 			isa = PBXGroup;
 			children = (
-				59D3685C247714DF0052F483 /* mock_nlu.tflite */,
+				59FE4A9624805F5F00976825 /* mock_detector.tflite */,
+				59FE4A9224805EA300976825 /* mock_filter.tflite */,
+				59FE4A8D2480580900976825 /* mock_encoder.tflite */,
+				59FE4A8C2480580900976825 /* mock_nlu.tflite */,
 				59A8DBF82384ABF000F97700 /* TextToSpeechTest.swift */,
 				59C2AFD92319CB7100E47AC5 /* RingBufferTest.swift */,
 				59D78F5E2322D13700728A98 /* AudioControllerTest.swift */,
@@ -354,6 +365,7 @@
 				5917AC4E2405C86300CB4900 /* NLUTensorflowSlotParserTest.swift */,
 				5917AC502405C89A00CB4900 /* SharedTestMocks.swift */,
 				59AA893C2472EE5500197D7A /* NLUTensorflowTest.swift */,
+				59AB0B0624786B69007B7582 /* TFLiteWakewordRecognizerTest.swift */,
 			);
 			path = SpokestackTests;
 			sourceTree = "<group>";
@@ -680,7 +692,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				59D3685D247714DF0052F483 /* mock_nlu.tflite in Resources */,
+				59FE4A912480580900976825 /* mock_encoder.tflite in Resources */,
+				59FE4A9724805F5F00976825 /* mock_detector.tflite in Resources */,
+				59FE4A902480580900976825 /* mock_nlu.tflite in Resources */,
+				59FE4A9324805EA300976825 /* mock_filter.tflite in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -861,6 +876,7 @@
 				59C2AFE52319CED100E47AC5 /* AppleSpeechRecognizer.swift in Sources */,
 				59C2AFDB2319CE5800E47AC5 /* SpeechConfiguration.swift in Sources */,
 				59EF51C32332E57B006BA0BD /* Frame.swift in Sources */,
+				59AB0B0724786B69007B7582 /* TFLiteWakewordRecognizerTest.swift in Sources */,
 				59EF51BF233013A9006BA0BD /* AppleSpeechRecognizerTest.swift in Sources */,
 				01D31F67216BAFB50055FD45 /* Error.swift in Sources */,
 			);

--- a/Spokestack/NLUTensorflow.swift
+++ b/Spokestack/NLUTensorflow.swift
@@ -100,9 +100,12 @@ import TensorFlowLite
         let inputCases = InputTensors.allCases.count
         let outputCount = self.interpreter!.outputTensorCount
         let outputCases = OutputTensors.allCases.count
-        if(inputCount != inputCases) || (outputCount != outputCases) {
+        if (inputCount != inputCases) || (outputCount != outputCases) {
             throw NLUError.model("NLU model provided is not shaped as expected. There are \(inputCount)/\(inputCases) inputs and \(outputCount)/\(outputCases) outputs")
         }
+        let dim = [Int32](repeating: Int32(0), count: self.configuration.nluMaxTokenLength)
+        _ = try dim.withUnsafeBytes { try self.interpreter!.copy(Data($0), toInputAt: InputTensors.input.rawValue) }
+        _ = try self.interpreter!.invoke()
     }
     
     /// Classifies the provided input. The classification results are sent to the instance's configured NLUDelegate.

--- a/Spokestack/SpeechConfiguration.swift
+++ b/Spokestack/SpeechConfiguration.swift
@@ -15,10 +15,6 @@ import Foundation
     /// - Warning: cannot contain spaces
     /// - SeeAlso: `AppleWakewordRecognizer`
     @objc public var wakewords: String = "spokestack, spoke stack"
-    /// A comma-separated list of space-separated wakeword keyword phrases to detect, which defaults to no phrases (just individual keywords).
-    /// - Remark: ex: "up dog,dog dog"
-    /// - SeeAlso: `AppleWakewordRecognizer`
-    @objc public var wakePhrases: String = "spokestack"
     /// The name of the window function to apply to each audio frame before calculating the STFT.
     /// - Remark: Currently the "hann" window is supported.
     /// - SeeAlso: `TFLiteWakewordRecognizer`

--- a/Spokestack/SpeechConfiguration.swift
+++ b/Spokestack/SpeechConfiguration.swift
@@ -120,7 +120,7 @@ import Foundation
     @objc public var nluModelMetadataPath: String = "nlu.json"
     /// The maximum utterance length the NLU can process. Determined  by the NLU model.
     /// - SeeAlso: `BertTokenizer`
-    @objc public var nluMaxTokenLength: Int = 128
+    @objc public var nluMaxTokenLength: Int = 50
     /// Debugging trace levels, for simple filtering.
     @objc public var tracing: Trace.Level = Trace.Level.NONE
     /// Delegate events will be sent using the specified dispatch queue.

--- a/Spokestack/WebRTCVAD.swift
+++ b/Spokestack/WebRTCVAD.swift
@@ -48,19 +48,19 @@ public class WebRTCVAD: NSObject {
     /// - Throws: VADError.invalidConfiguration if the frameWidth or sampleRate are not supported.
     public func create(mode: VADMode, delegate: VADDelegate, frameWidth: Int, sampleRate: Int) throws {
         
-        /// validation of configurable parameters
+        // validation of configurable parameters
         try self.validate(frameWidth: frameWidth, sampleRate: sampleRate)
         
         /// set public property
         self.delegate = delegate
         
-        /// set private properties
-        frameBufferStride = frameWidth*(sampleRate/1000) /// eg 20*(16000/1000) = 320
+        // set private properties
+        frameBufferStride = frameWidth*(sampleRate/1000) // eg 20*(16000/1000) = 320
         sampleRate32 = Int32(sampleRate)
         frameBufferStride32 = Int32(frameBufferStride)
         frameBuffer = RingBuffer(frameBufferStride, repeating: 0)
         
-        /// initialize WebRtcVad with provided configuration
+        // initialize WebRtcVad with provided configuration
         var errorCode:Int32 = 0
         errorCode = WebRtcVad_Create(vad)
         if errorCode != 0 { throw VADError.initialization("unable to create a WebRTCVAD struct, which returned error code \(errorCode)") }
@@ -95,10 +95,10 @@ public class WebRTCVAD: NSObject {
             var detected: Bool = false
             let samples: Array<Int16> = frame.elements()
             for s in samples {
-                /// write the frame sample to the buffer
+                // write the frame sample to the buffer
                 try frameBuffer.write(s)
                 if frameBuffer.isFull {
-                    /// once the buffer is full, process its samples
+                    // once the buffer is full, process its samples
                     detecting: while !frameBuffer.isEmpty {
                         var sampleWindow: Array<Int16> = []
                         for _ in 0..<frameBufferStride {

--- a/SpokestackTests/AppleWakewordRecognizerTest.swift
+++ b/SpokestackTests/AppleWakewordRecognizerTest.swift
@@ -27,9 +27,11 @@ class AppleWakewordRecognizerTest: XCTestCase {
         awr.configuration = SpeechConfiguration()
         awr.delegate = delegate
         XCTAssertNoThrow(awr.startStreaming(context: context))
+        XCTAssert(context.isStarted)
         
         /// stopStreaming
         XCTAssertNoThrow(awr.stopStreaming(context: context))
+        XCTAssertFalse(context.isStarted)
     }
     
     /// process

--- a/SpokestackTests/NLUTensorflowTest.swift
+++ b/SpokestackTests/NLUTensorflowTest.swift
@@ -1,0 +1,111 @@
+//
+//  NLUTensorflowTest.swift
+//  SpokestackTests
+//
+//  Created by Noel Weichbrodt on 5/18/20.
+//  Copyright © 2020 Spokestack, Inc. All rights reserved.
+//
+
+import Foundation
+@testable import TensorFlowLite
+@testable import Spokestack
+import XCTest
+
+class NLUTensorflowTest: XCTestCase {
+    func testInvoke() {
+        let i = try! Interpreter(modelPath: NLUModel.path)
+        try! i.allocateTensors()
+        _ = NLUModel.input.withUnsafeBytes { try! i.copy(Data($0), toInputAt: 0) }
+        _ = try! i.invoke()
+        let output = try! i.output(at: NLUModel.validIndex)
+        XCTAssertEqual(output.data, NLUModel.outputData)
+        let result = output.data.toArray(type: Int32.self, count: output.data.count/4)
+        XCTAssertEqual(result, [0, 0, 0, 0, 0, 0, 0, 0])
+    }
+    
+    func testInit() {
+        // bad config calls delegate.failure
+        let config = SpeechConfiguration()
+        config.nluVocabularyPath = SharedTestMocks.createVocabularyPath()
+        config.nluModelMetadataPath = SharedTestMocks.createModelMetadataPath()
+        let delegate = TestNLUDelegate()
+        let didFailExpectation = expectation(description: "unsuccessful initialization calls TestNLUDelegate.failure")
+        delegate.asyncExpectation = didFailExpectation
+        let _ = try! NLUTensorflow(delegate, configuration: config)
+        wait(for: [didFailExpectation], timeout: 5)
+        XCTAssert(delegate.didFail)
+        
+        // good config can init
+        config.nluModelPath = NLUModel.path
+        let _ = try! NLUTensorflow(configuration: config)
+    }
+    
+    func testClassify() {
+        // unsuccessful classification calls delegate.failure
+        let config = SpeechConfiguration()
+        config.nluVocabularyPath = SharedTestMocks.createVocabularyPath()
+        config.nluModelMetadataPath = SharedTestMocks.createModelMetadataPath()
+        config.nluModelPath = NLUModel.path
+        let delegate = TestNLUDelegate()
+        let nlu = try! NLUTensorflow(delegate, configuration: config)
+        nlu.configuration.nluMaxTokenLength = -1
+        let didFailExpectation = expectation(description: "unsuccessful classify calls TestNLUDelegate.failure")
+        delegate.asyncExpectation = didFailExpectation
+        nlu.classify(utterance: "")
+        wait(for: [didFailExpectation], timeout: 5)
+        XCTAssertFalse(delegate.didClassify)
+        XCTAssert(delegate.didFail)
+        nlu.configuration.nluMaxTokenLength = 128
+        delegate.reset()
+        
+        // successful classification calls delegate.classify
+        let didSucceedExpectation = expectation(description: "successful classification calls TestNLUDelegate.classify")
+        delegate.asyncExpectation = didSucceedExpectation
+        nlu.classify(utterance: "")
+        wait(for: [didSucceedExpectation], timeout: 5)
+        XCTAssert(delegate.didClassify)
+        XCTAssertFalse(delegate.didFail)
+    }
+}
+
+fileprivate enum NLUModel {
+    static let info = (name: "mock_nlu", extension: "tflite")
+    static let input = [Int32](Array(repeating: 0, count: 128)).withUnsafeBufferPointer(Data.init)
+    static let validIndex = 0
+    static let shape: TensorShape = [2]
+    static let inputData = [Int32]([Int32(1), Int32(3)]).withUnsafeBufferPointer(Data.init)
+    static let outputData = [Int32]([0, 0, 0, 0, 0, 0, 0, 0]).withUnsafeBufferPointer(Data.init)
+    static var path: String = {
+        let bundle = Bundle(for: NLUTensorflowTest.self)
+        let p = bundle.path(forResource: info.name, ofType: info.extension)
+        return p!
+    }()
+}
+
+class TestNLUDelegate: NLUDelegate {
+    /// Spy pattern for the system under test.
+    /// asyncExpectation lets the caller's test know when the delegate has been called.
+    var didClassify: Bool = false
+    var didFail: Bool = false
+    var asyncExpectation: XCTestExpectation?
+    
+    func reset() {
+        didClassify = false
+        didFail = false
+        asyncExpectation = .none
+    }
+    
+    func classification(result: NLUResult) {
+        asyncExpectation?.fulfill()
+        didClassify = true
+    }
+    
+    func didTrace(_ trace: String) {
+        print(trace)
+    }
+    
+    func failure(nluError: Error) {
+        asyncExpectation?.fulfill()
+        didFail = true
+    }
+}

--- a/SpokestackTests/NLUTensorflowTest.swift
+++ b/SpokestackTests/NLUTensorflowTest.swift
@@ -34,10 +34,12 @@ class NLUTensorflowTest: XCTestCase {
         let _ = try! NLUTensorflow(delegate, configuration: config)
         wait(for: [didFailExpectation], timeout: 5)
         XCTAssert(delegate.didFail)
+        delegate.reset()
         
         // good config can init
         config.nluModelPath = NLUModel.path
         let _ = try! NLUTensorflow(configuration: config)
+        XCTAssertFalse(delegate.didFail)
     }
     
     func testClassify() {
@@ -83,8 +85,8 @@ fileprivate enum NLUModel {
 }
 
 class TestNLUDelegate: NLUDelegate {
-    /// Spy pattern for the system under test.
-    /// asyncExpectation lets the caller's test know when the delegate has been called.
+    // Spy pattern for the system under test.
+    // asyncExpectation lets the caller's test know when the delegate has been called.
     var didClassify: Bool = false
     var didFail: Bool = false
     var asyncExpectation: XCTestExpectation?

--- a/SpokestackTests/SharedTestMocks.swift
+++ b/SpokestackTests/SharedTestMocks.swift
@@ -19,6 +19,18 @@ internal struct SharedTestMocks {
         return encodings
     }
     
+    static func createModelMetadataPath() -> String {
+        let path = NSTemporaryDirectory() + "nlu.json"
+        let model = #"""
+                {
+                  "intents": [{"name": "","slots": []}],
+                  "tags": ["o"]
+                }
+        """#
+        let _ = FileManager.default.createFile(atPath: path, contents: model.data(using: .utf8), attributes: .none)
+        return path
+    }
+    
     static func createVocabularyPath() -> String {
         let path = NSTemporaryDirectory() + "vocab.txt"
         let vocab = """

--- a/SpokestackTests/TFLiteWakewordRecognizerTest.swift
+++ b/SpokestackTests/TFLiteWakewordRecognizerTest.swift
@@ -14,6 +14,11 @@ import XCTest
 
 class TFLiteWakewordRecognizerTest: XCTestCase {
     
+    let tflwr = TFLiteWakewordRecognizer.sharedInstance
+    let context = SpeechContext()
+    let delegate = TFLiteWakewordRecognizerTestDelegate()
+    let config = SpeechConfiguration()
+    
     func hexStringToData(hexString: String) -> Data? {
         let len = hexString.count / 2
         var data = Data(capacity: len)
@@ -31,6 +36,12 @@ class TFLiteWakewordRecognizerTest: XCTestCase {
     }
     
     override func setUp() {
+        self.config.encodeModelPath = MockWakewordModels.encodePath
+        self.config.filterModelPath = MockWakewordModels.filterPath
+        self.config.detectModelPath = MockWakewordModels.detectPath
+        self.tflwr.configuration = config
+        self.tflwr.context = context
+        self.tflwr.delegate = delegate
         //let filterHexString = filter.map { String(format: "%02hhx", $0) }.joined()
         //let filterData = hexStringToData(hexString: MockWakewordModels.filterString)
         //let _ = FileManager.default.createFile(atPath: MockWakewordModels.filterPath, contents: filterData, attributes: .none)
@@ -70,73 +81,40 @@ class TFLiteWakewordRecognizerTest: XCTestCase {
     }
     
     func testStartStop() {
-        // setup
-        let tflwr = TFLiteWakewordRecognizer.sharedInstance
-        let context = SpeechContext()
-        let delegate = TFLiteWakewordRecognizerTestDelegate()
-        let config = SpeechConfiguration()
-        config.encodeModelPath = MockWakewordModels.encodePath
-        config.filterModelPath = MockWakewordModels.filterPath
-        config.detectModelPath = MockWakewordModels.detectPath
-        tflwr.configuration = config
-        tflwr.context = context
-        tflwr.delegate = delegate
-        
         // start
-        context.isActive = false
-        tflwr.startStreaming(context: context)
-        XCTAssert(context.isStarted)
+        self.context.isActive = false
+        self.tflwr.startStreaming(context: self.context)
+        XCTAssert(self.context.isStarted)
         // stop
-        tflwr.stopStreaming(context: context)
-        XCTAssertFalse(context.isStarted)
+        self.tflwr.stopStreaming(context: self.context)
+        XCTAssertFalse(self.context.isStarted)
     }
     
     func testActivatetDeactivate() {
-        // setup
-        let tflwr = TFLiteWakewordRecognizer.sharedInstance
-        let context = SpeechContext()
-        let delegate = TFLiteWakewordRecognizerTestDelegate()
-        let config = SpeechConfiguration()
-        config.encodeModelPath = MockWakewordModels.encodePath
-        config.filterModelPath = MockWakewordModels.filterPath
-        config.detectModelPath = MockWakewordModels.detectPath
-        tflwr.configuration = config
-        tflwr.context = context
-        tflwr.delegate = delegate
-        
         // start
-        context.isActive = false
-        tflwr.startStreaming(context: context)
-        tflwr.activate(frame: Frame.voice(frameWidth: 10, sampleRate: 8000))
-        XCTAssert(context.isSpeech)
-        tflwr.deactivate()
-        XCTAssertFalse(context.isSpeech)
+        self.context.isActive = false
+        self.tflwr.startStreaming(context: self.context)
+        self.tflwr.activate(frame: Frame.voice(frameWidth: 10, sampleRate: 8000))
+        XCTAssert(self.context.isSpeech)
+        // stop
+        self.tflwr.deactivate()
+        XCTAssertFalse(self.context.isSpeech)
     }
     
     func testProcess() {
         // setup
-        let tflwr = TFLiteWakewordRecognizer.sharedInstance
-        let context = SpeechContext()
-        let delegate = TFLiteWakewordRecognizerTestDelegate()
-        let config = SpeechConfiguration()
         let successExpectation = XCTestExpectation(description: "process without failure.")
-        delegate.didActivateExpectation = successExpectation
-        config.encodeModelPath = MockWakewordModels.encodePath
-        config.filterModelPath = MockWakewordModels.filterPath
-        config.detectModelPath = MockWakewordModels.detectPath
-        config.vadMode = .HighlyPermissive
-        tflwr.configuration = config
-        tflwr.context = context
-        tflwr.delegate = delegate
+        self.delegate.didActivateExpectation = successExpectation
+        self.tflwr.configuration?.vadMode = .HighlyPermissive
         
         // process
-        context.isActive = false
-        context.isSpeech = false
+        self.context.isActive = false
+        self.context.isSpeech = false
         // NB: the detect model will always output 1.0 no matter the input
-        tflwr.process(Frame.voice(frameWidth: 10, sampleRate: 16000))
+        self.tflwr.process(Frame.voice(frameWidth: 10, sampleRate: 16000))
         wait(for: [successExpectation], timeout: 5)
-        XCTAssert(context.isActive)
-        XCTAssertFalse(delegate.didError)
+        XCTAssert(self.context.isActive)
+        XCTAssertFalse(self.delegate.didError)
     }
 }
 
@@ -173,12 +151,11 @@ fileprivate enum MockWakewordModels {
         let p = bundle.path(forResource: detectInfo.name, ofType: detectInfo.extension)
         return p!
     }()
-    // static let filterString = "5b3078316330302c203078303030302c203078353434362c203078346333332c203078303030302c203078313230302c203078316330302c203078303430302c0a3078303830302c203078306330302c203078313030302c203078313430302c203078303030302c203078313830302c203078313230302c203078303030302c0a3078303330302c203078303030302c203078313430302c203078303030302c203078313430302c203078303030302c203078376330302c203078303030302c0a3078313430302c203078303030302c203078323430302c203078303030302c203078303030302c203078303030302c203078303130302c203078303030302c0a3078386330302c203078303030302c203078303430302c203078303030302c203078663430312c203078303030302c203078663030312c203078303030302c0a3078633430302c203078303030302c203078333830302c203078303030302c203078303130302c203078303030302c203078306330302c20303030302c0a3078303830302c203078306330302c203078303430302c203078303830302c203078303830302c203078303030302c203078303830302c20303030302c0a3078303330302c203078303030302c203078313330302c203078303030302c203078366436392c203078366535662c203078373237352c20366537342c0a3078363936642c203078363535662c203078373636352c203078373237332c203078363936662c203078366530302c203078376566662c20666666662c0a3078303430302c203078303030302c203078313030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078306630302c203078303030302c203078346434632c20343935322c0a3078323034332c203078366636652c203078373636352c203078373237342c203078363536342c203078326530302c203078303030302c20306530302c0a3078313830302c203078303430302c203078303830302c203078306330302c203078313030302c203078313430302c203078306530302c20303030302c0a3078313430302c203078303030302c203078316330302c203078303030302c203078323030302c203078303030302c203078323430302c20303030302c0a3078323430302c203078303030302c203078303230302c203078303030302c203078323030312c203078303030302c203078643430302c20303030302c0a3078303130302c203078303030302c203078303030302c203078303030302c203078303130302c203078303030302c203078303130302c20303030302c0a3078303030302c203078303030302c203078303430302c203078303030302c203078366436312c203078363936652c203078303030302c20303630302c0a3078303830302c203078303430302c203078303630302c203078303030302c203078303430302c203078303030302c203078613030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078633666662c203078666666662c203078313030302c203078303030302c203078303230302c203078303030302c203078313430302c20303030302c0a3078323430302c203078303030302c203078303230302c203078303030302c203078303130302c203078303030302c203078323830302c20303030302c0a3078303830302c203078303030302c203078343936342c203078363536652c203078373436392c203078373437392c203078303030302c20303030302c0a3078303430302c203078303630302c203078303430302c203078303030302c203078303030302c203078306530302c203078313430302c20303430302c0a3078303030302c203078303830302c203078306330302c203078313030302c203078306530302c203078303030302c203078313030302c20303030302c0a3078303130302c203078303030302c203078313430302c203078303030302c203078316330302c203078303030302c203078303230302c20303030302c0a3078303130302c203078303030302c203078303130312c203078303030302c203078303630302c203078303030302c203078363936652c20373037352c0a3078373437332c203078303030302c203078666366662c203078666666662c203078303430302c203078303430302c203078303430302c20303030305d0a"
 }
 
 class TFLiteWakewordRecognizerTestDelegate: PipelineDelegate, SpeechEventListener {
-    /// Spy pattern for the system under test.
-    /// asyncExpectation lets the caller's test know when the delegate has been called.
+    // Spy pattern for the system under test.
+    // asyncExpectation lets the caller's test know when the delegate has been called.
     var didError: Bool = false
     var deactivated: Bool = false
     var activated: Bool = false

--- a/SpokestackTests/TFLiteWakewordRecognizerTest.swift
+++ b/SpokestackTests/TFLiteWakewordRecognizerTest.swift
@@ -1,0 +1,234 @@
+//
+//  TFLiteWakewordRecognizerTest.swift
+//  SpokestackTests
+//
+//  Created by Noel Weichbrodt on 5/22/20.
+//  Copyright © 2020 Spokestack, Inc. All rights reserved.
+//
+
+import Foundation
+import CryptoKit
+@testable import TensorFlowLite
+@testable import Spokestack
+import XCTest
+
+class TFLiteWakewordRecognizerTest: XCTestCase {
+    
+    func hexStringToData(hexString: String) -> Data? {
+        let len = hexString.count / 2
+        var data = Data(capacity: len)
+        for i in 0..<len {
+            let j = hexString.index(hexString.startIndex, offsetBy: i*2)
+            let k = hexString.index(j, offsetBy: 2)
+            let bytes = hexString[j..<k]
+            if var num = UInt8(bytes, radix: 16) {
+                data.append(&num, count: 1)
+            } else {
+                return nil
+            }
+        }
+        return data
+    }
+    
+    override func setUp() {
+        //let filterHexString = filter.map { String(format: "%02hhx", $0) }.joined()
+        //let filterData = hexStringToData(hexString: MockWakewordModels.filterString)
+        //let _ = FileManager.default.createFile(atPath: MockWakewordModels.filterPath, contents: filterData, attributes: .none)
+    }
+    
+    func testInvoke() {
+        // filter
+        let filter = try! Interpreter(modelPath: MockWakewordModels.filterPath)
+        try! filter.allocateTensors()
+        _ = MockWakewordModels.filterInput.withUnsafeBytes { try! filter.copy(Data($0), toInputAt: 0) }
+        _ = try! filter.invoke()
+        let filterOutput = try! filter.output(at: MockWakewordModels.validIndex)
+        XCTAssertEqual(filterOutput.data, MockWakewordModels.filterOutputData)
+        let filterResult = filterOutput.data.toArray(type: Int32.self, count: filterOutput.data.count/4)
+        XCTAssertEqual(filterResult, MockWakewordModels.filterOutput)
+        
+        // encode
+        let encoder = try! Interpreter(modelPath: MockWakewordModels.encodePath)
+        try! encoder.allocateTensors()
+        _ = MockWakewordModels.encodeInput.withUnsafeBytes { try! encoder.copy(Data($0), toInputAt: 0) }
+        _ = MockWakewordModels.input.withUnsafeBytes { try! encoder.copy(Data($0), toInputAt: 1) }
+        _ = try! encoder.invoke()
+        let encoderOutput = try! encoder.output(at: MockWakewordModels.validIndex)
+        XCTAssertEqual(encoderOutput.data, MockWakewordModels.encodeOutputData)
+        let encoderResult = encoderOutput.data.toArray(type: Int32.self, count: encoderOutput.data.count/4)
+        XCTAssertEqual(encoderResult, MockWakewordModels.encodeOutput)
+        
+        // detect
+        let detect = try! Interpreter(modelPath: MockWakewordModels.detectPath)
+        try! detect.allocateTensors()
+        _ = MockWakewordModels.detectInput.withUnsafeBytes { try! detect.copy(Data($0), toInputAt: 0) }
+        _ = try! detect.invoke()
+        let detectOutput = try! detect.output(at: MockWakewordModels.validIndex)
+        XCTAssertEqual(detectOutput.data, MockWakewordModels.detectOutputData)
+        let detectResult = detectOutput.data.toArray(type: Int32.self, count: detectOutput.data.count/4)
+        XCTAssertEqual(detectResult, MockWakewordModels.detectOutput)
+    }
+    
+    func testStartStop() {
+        // setup
+        let tflwr = TFLiteWakewordRecognizer.sharedInstance
+        let context = SpeechContext()
+        let delegate = TFLiteWakewordRecognizerTestDelegate()
+        let config = SpeechConfiguration()
+        config.encodeModelPath = MockWakewordModels.encodePath
+        config.filterModelPath = MockWakewordModels.filterPath
+        config.detectModelPath = MockWakewordModels.detectPath
+        tflwr.configuration = config
+        tflwr.context = context
+        tflwr.delegate = delegate
+        
+        // start
+        context.isActive = false
+        tflwr.startStreaming(context: context)
+        XCTAssert(context.isStarted)
+        // stop
+        tflwr.stopStreaming(context: context)
+        XCTAssertFalse(context.isStarted)
+    }
+    
+    func testActivatetDeactivate() {
+        // setup
+        let tflwr = TFLiteWakewordRecognizer.sharedInstance
+        let context = SpeechContext()
+        let delegate = TFLiteWakewordRecognizerTestDelegate()
+        let config = SpeechConfiguration()
+        config.encodeModelPath = MockWakewordModels.encodePath
+        config.filterModelPath = MockWakewordModels.filterPath
+        config.detectModelPath = MockWakewordModels.detectPath
+        tflwr.configuration = config
+        tflwr.context = context
+        tflwr.delegate = delegate
+        
+        // start
+        context.isActive = false
+        tflwr.startStreaming(context: context)
+        tflwr.activate(frame: Frame.voice(frameWidth: 10, sampleRate: 8000))
+        XCTAssert(context.isSpeech)
+        tflwr.deactivate()
+        XCTAssertFalse(context.isSpeech)
+    }
+    
+    func testProcess() {
+        // setup
+        let tflwr = TFLiteWakewordRecognizer.sharedInstance
+        let context = SpeechContext()
+        let delegate = TFLiteWakewordRecognizerTestDelegate()
+        let config = SpeechConfiguration()
+        let successExpectation = XCTestExpectation(description: "process without failure.")
+        delegate.didActivateExpectation = successExpectation
+        config.encodeModelPath = MockWakewordModels.encodePath
+        config.filterModelPath = MockWakewordModels.filterPath
+        config.detectModelPath = MockWakewordModels.detectPath
+        config.vadMode = .HighlyPermissive
+        tflwr.configuration = config
+        tflwr.context = context
+        tflwr.delegate = delegate
+        
+        // process
+        context.isActive = false
+        context.isSpeech = false
+        // NB: the detect model will always output 1.0 no matter the input
+        tflwr.process(Frame.voice(frameWidth: 10, sampleRate: 16000))
+        wait(for: [successExpectation], timeout: 5)
+        XCTAssert(context.isActive)
+        XCTAssertFalse(delegate.didError)
+    }
+}
+
+fileprivate enum MockWakewordModels {
+    static let filterInfo = (name: "mock_filter", extension: "tflite")
+    static let encodeInfo = (name: "mock_encoder", extension: "tflite")
+    static let detectInfo = (name: "mock_detector", extension: "tflite")
+    static let input = [Int32](Array(repeating: 0, count: 128)).withUnsafeBufferPointer(Data.init)
+    static let filterInput = [Int32](Array(repeating: 0, count: 257)).withUnsafeBufferPointer(Data.init)
+    static let encodeInput = [Int32](Array(repeating: 0, count: 40)).withUnsafeBufferPointer(Data.init)
+    static let detectInput = [Int32](Array(repeating: 0, count: 12800)).withUnsafeBufferPointer(Data.init)
+    static let validIndex = 0
+    static let shape: TensorShape = [2]
+    static let output = [Int32](Array(repeating: 0, count: 40))
+    static let outputData = output.withUnsafeBufferPointer(Data.init)
+    static let filterOutput = [Int32](Array(repeating: 0, count: 40))
+    static let filterOutputData = filterOutput.withUnsafeBufferPointer(Data.init)
+    static let encodeOutput = [Int32](Array(repeating: 0, count: 128))
+    static let encodeOutputData = encodeOutput.withUnsafeBufferPointer(Data.init)
+    static let detectOutput = [Int32](arrayLiteral: 1065353216)
+    static let detectOutputData = detectOutput.withUnsafeBufferPointer(Data.init)
+    static var filterPath: String = {
+        let bundle = Bundle(for: TFLiteWakewordRecognizerTest.self)
+        let p = bundle.path(forResource: filterInfo.name, ofType: filterInfo.extension)
+        return p!
+    }() // String = NSTemporaryDirectory() + MockWakewordModels.filterInfo.name + "." + MockWakewordModels.filterInfo.extension
+    static var encodePath: String = {
+        let bundle = Bundle(for: TFLiteWakewordRecognizerTest.self)
+        let p = bundle.path(forResource: encodeInfo.name, ofType: encodeInfo.extension)
+        return p!
+    }()
+    static var detectPath: String = {
+        let bundle = Bundle(for: TFLiteWakewordRecognizerTest.self)
+        let p = bundle.path(forResource: detectInfo.name, ofType: detectInfo.extension)
+        return p!
+    }()
+    // static let filterString = "5b3078316330302c203078303030302c203078353434362c203078346333332c203078303030302c203078313230302c203078316330302c203078303430302c0a3078303830302c203078306330302c203078313030302c203078313430302c203078303030302c203078313830302c203078313230302c203078303030302c0a3078303330302c203078303030302c203078313430302c203078303030302c203078313430302c203078303030302c203078376330302c203078303030302c0a3078313430302c203078303030302c203078323430302c203078303030302c203078303030302c203078303030302c203078303130302c203078303030302c0a3078386330302c203078303030302c203078303430302c203078303030302c203078663430312c203078303030302c203078663030312c203078303030302c0a3078633430302c203078303030302c203078333830302c203078303030302c203078303130302c203078303030302c203078306330302c20303030302c0a3078303830302c203078306330302c203078303430302c203078303830302c203078303830302c203078303030302c203078303830302c20303030302c0a3078303330302c203078303030302c203078313330302c203078303030302c203078366436392c203078366535662c203078373237352c20366537342c0a3078363936642c203078363535662c203078373636352c203078373237332c203078363936662c203078366530302c203078376566662c20666666662c0a3078303430302c203078303030302c203078313030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078306630302c203078303030302c203078346434632c20343935322c0a3078323034332c203078366636652c203078373636352c203078373237342c203078363536342c203078326530302c203078303030302c20306530302c0a3078313830302c203078303430302c203078303830302c203078306330302c203078313030302c203078313430302c203078306530302c20303030302c0a3078313430302c203078303030302c203078316330302c203078303030302c203078323030302c203078303030302c203078323430302c20303030302c0a3078323430302c203078303030302c203078303230302c203078303030302c203078323030312c203078303030302c203078643430302c20303030302c0a3078303130302c203078303030302c203078303030302c203078303030302c203078303130302c203078303030302c203078303130302c20303030302c0a3078303030302c203078303030302c203078303430302c203078303030302c203078366436312c203078363936652c203078303030302c20303630302c0a3078303830302c203078303430302c203078303630302c203078303030302c203078303430302c203078303030302c203078613030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c203078303030302c20303030302c0a3078633666662c203078666666662c203078313030302c203078303030302c203078303230302c203078303030302c203078313430302c20303030302c0a3078323430302c203078303030302c203078303230302c203078303030302c203078303130302c203078303030302c203078323830302c20303030302c0a3078303830302c203078303030302c203078343936342c203078363536652c203078373436392c203078373437392c203078303030302c20303030302c0a3078303430302c203078303630302c203078303430302c203078303030302c203078303030302c203078306530302c203078313430302c20303430302c0a3078303030302c203078303830302c203078306330302c203078313030302c203078306530302c203078303030302c203078313030302c20303030302c0a3078303130302c203078303030302c203078313430302c203078303030302c203078316330302c203078303030302c203078303230302c20303030302c0a3078303130302c203078303030302c203078303130312c203078303030302c203078303630302c203078303030302c203078363936652c20373037352c0a3078373437332c203078303030302c203078666366662c203078666666662c203078303430302c203078303430302c203078303430302c20303030305d0a"
+}
+
+class TFLiteWakewordRecognizerTestDelegate: PipelineDelegate, SpeechEventListener {
+    /// Spy pattern for the system under test.
+    /// asyncExpectation lets the caller's test know when the delegate has been called.
+    var didError: Bool = false
+    var deactivated: Bool = false
+    var activated: Bool = false
+    var asyncExpectation: XCTestExpectation?
+    var didActivateExpectation: XCTestExpectation?
+
+    func reset() {
+        self.didError = false
+        self.deactivated = false
+        self.activated = false
+        asyncExpectation = .none
+        self.didActivateExpectation = .none
+    }
+    
+    func didRecognize(_ result: SpeechContext) {}
+    
+    func failure(speechError: Error) {
+        print(speechError)
+        guard let _ = asyncExpectation else {
+            XCTFail("TFLiteWakewordRecognizerTestDelegate was not setup correctly. Missing XCTExpectation reference")
+            return
+        }
+        self.didError = true
+        self.asyncExpectation?.fulfill()
+    }
+    
+    func didTimeout() {}
+    
+    func didActivate() {
+        guard let _ = self.didActivateExpectation else {
+            XCTFail("TFLiteWakewordRecognizerTestDelegate was not setup correctly. Missing XCTExpectation reference")
+            return
+        }
+        self.activated = true
+        self.didActivateExpectation?.fulfill()
+    }
+    
+    func didDeactivate() {
+        self.deactivated = true
+    }
+    
+    func didInit() {}
+    
+    func didStart() {}
+    
+    func didStop() {}
+    
+    func setupFailed(_ error: String) {}
+    
+    func didTrace(_ trace: String) {
+        print(trace)
+    }
+}

--- a/SpokestackTests/mock_detector.tflite
+++ b/SpokestackTests/mock_detector.tflite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f076e15e4174e163137e84401b278b64c5bc755b3a28bfe87b5c621fee44fb0
+size 424

--- a/SpokestackTests/mock_encoder.tflite
+++ b/SpokestackTests/mock_encoder.tflite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d99f592cf59ccaccda3b23a941903e6dc4742d656d06ae65823de098ab697f6
+size 1020

--- a/SpokestackTests/mock_filter.tflite
+++ b/SpokestackTests/mock_filter.tflite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f59e177a4bcd1f30c40ba865ebd1bcc672f0a515463d81236eb98e464943dd6a
+size 576

--- a/SpokestackTests/mock_nlu.tflite
+++ b/SpokestackTests/mock_nlu.tflite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa6b8ab38bc5a0ed4d5eaf850ebe3aff93f3a65372e02ba48bf1884129e4de9a
+size 4628


### PR DESCRIPTION
Tests for tensorflow-using modules. 

Real TF models are necessary due to TFLite-Swift classes marked final, which are uninhabitable and non-mockable, and the majority of properties are immutable based on the actual model. I attempted to get these simple models stored as source code in the tests themselves but got stuck on io not preserving types correctly.