### PR TITLE
NLU returns an empty slot instead of crashing

### DIFF
--- a/Spokestack/NLUResult.swift
+++ b/Spokestack/NLUResult.swift
@@ -69,6 +69,8 @@ import Foundation
     
     /// The slot's value.
     @objc public var value: Any?
+    
+    @objc public var rawValue: String?
 
     public override var description: String {
         return "(\(type): \(value ?? ""))"
@@ -78,9 +80,10 @@ import Foundation
     /// - Parameters:
     ///   - type: The underlying type of the slot value.
     ///   - value: The slot's value.
-    public init(type: String, value: Any?) {
+    public init(type: String, value: Any?, rawValue: String?) {
         self.type = type
         self.value = value
+        self.rawValue = rawValue
         super.init()
     }
 }

--- a/Spokestack/NLUTensorflowSlotParsers.swift
+++ b/Spokestack/NLUTensorflowSlotParsers.swift
@@ -23,7 +23,7 @@ internal struct NLUTensorflowSlotParser {
     internal func parse(tags: [String], intent: NLUTensorflowIntent, encoder: BertTokenizer, encodedTokens: EncodedTokens) throws -> [String:Slot]? {
         // zip together the tags (ignoring the "o" tag) and the index of the whitespaced encoded tokens, then process into the return type
         let tagsToTokens = zipTagsAndTokens(tags: tags, encodedTokens: encodedTokens)
-        // intents defined a fixed set of slots, so for each slot in the intent determine if the model has produced a value for it.
+        // intents define a fixed set of slots, so for each slot in the intent, determine if the model has produced a value for it.
         return try intentSlotMap(intent: intent, tagsToTokens: tagsToTokens, encoder: encoder, encodedTokens: encodedTokens)
     }
     

--- a/Spokestack/NLUTensorflowSlotParsers.swift
+++ b/Spokestack/NLUTensorflowSlotParsers.swift
@@ -35,11 +35,9 @@ internal struct NLUTensorflowSlotParser {
             // send each tag's tokens through the slot parser and return the result
             .reduce(into: [:] as [String:Slot], { result, dictionaryEntry in
                 let (tag, whitespaceIndices) = dictionaryEntry
-                guard let slot = intent.slots.filter({ $0.name == tag }).first else {
-                    throw NLUError.metadata("Could not find a slot called \(tag) in NLU model metadata.")
-                }
-                if let slotValue = try self.slotFacetParser(slot: slot, whitespaceIndices: whitespaceIndices, encoder: encoder, encodedTokens: encodedTokens) {
-                    result[tag] = Slot(type: slot.type, value: slotValue)
+                let slot = intent.slots.filter({ $0.name == tag }).first
+                if let s = slot, let slotValue = try self.slotFacetParser(slot: s, whitespaceIndices: whitespaceIndices, encoder: encoder, encodedTokens: encodedTokens) {
+                    result[tag] = Slot(type: s.type, value: slotValue)
                 }
             })
         return slots.isEmpty ? nil : slots

--- a/Spokestack/SpeechConfiguration.swift
+++ b/Spokestack/SpeechConfiguration.swift
@@ -14,7 +14,7 @@ import Foundation
     /// - Remark: ex: "up,dog"
     /// - Warning: cannot contain spaces
     /// - SeeAlso: `AppleWakewordRecognizer`
-    @objc public var wakewords: String = "spokestack, spoke stack"
+    @objc public var wakewords: String = "spokestack, spoke stack, smokestack, smoke stack"
     /// The name of the window function to apply to each audio frame before calculating the STFT.
     /// - Remark: Currently the "hann" window is supported.
     /// - SeeAlso: `TFLiteWakewordRecognizer`

--- a/SpokestackTests/NLUTensorflowSlotParserTest.swift
+++ b/SpokestackTests/NLUTensorflowSlotParserTest.swift
@@ -29,7 +29,8 @@ class NLUTensorflowSlotParserTest: XCTestCase {
         let et = EncodedTokens(tokensByWhitespace: ["kitchen"], encodedTokensByWhitespaceIndex: [0], encoded: [])
         let parsedSelset = try! parser.parse(tags: ["b_location"], intent: metadata!.intents.filter({ $0.name == "request.lights.deactivate" }).first!, encoder: encoder!, encodedTokens: et)
         XCTAssertEqual(parsedSelset!["location"]!.value as! String, "room")
-        
+        XCTAssertEqual(parsedSelset!["location"]!.rawValue!, "kitchen")
+
         // selset value has appended punctuation
         let et2 = EncodedTokens(tokensByWhitespace: ["kitchen."], encodedTokensByWhitespaceIndex: [0], encoded: [])
         let parsedSelset2 = try! parser.parse(tags: ["b_location"], intent: metadata!.intents.filter({ $0.name == "request.lights.deactivate" }).first!, encoder: encoder!, encodedTokens: et2)
@@ -40,7 +41,8 @@ class NLUTensorflowSlotParserTest: XCTestCase {
         let et1 = EncodedTokens(tokensByWhitespace: ["ten"], encodedTokensByWhitespaceIndex: [0], encoded: [])
         let parsedInteger10 = try! parser.parse(tags: ["b_rating"], intent: metadata!.intents.filter({ $0.name == "rate.app" }).first!, encoder: encoder!, encodedTokens: et1)
         XCTAssertEqual(parsedInteger10!["rating"]!.value as! Int, 10)
-        
+        XCTAssertEqual(parsedInteger10!["rating"]!.rawValue!, "ten")
+
         let et2 = EncodedTokens(tokensByWhitespace: ["fiftie", "one"],  encodedTokensByWhitespaceIndex: [0, 0, 0, 1], encoded: [])
         let parsedInteger51 = try! parser.parse(tags: ["b_rating", "i_rating", "i_rating", "i_rating"], intent: metadata!.intents.filter({ $0.name == "rate.app" }).first!, encoder: encoder!, encodedTokens: et2)
         XCTAssertEqual(parsedInteger51!["rating"]!.value as! Int, 51)
@@ -62,9 +64,11 @@ class NLUTensorflowSlotParserTest: XCTestCase {
         XCTAssertEqual(parsedDigitsNumeric!["phone_number"]!.value as! String, "4238341746")
 
         let taggedInputPhoneCardinal = ["b_phone_number", "i_phone_number", "i_phone_number", "i_phone_number", "i_phone_number", "i_phone_number", "i_phone_number", "i_phone_number", "i_phone_number", "i_phone_number"]
-        let et6 = EncodedTokens(tokensByWhitespace: ["4", "second", "three", "eighth", "three", "four", "one", "seven", "four", "six"], encodedTokensByWhitespaceIndex: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], encoded: [])
+        let inputPhoneCardinal = ["4", "second", "three", "eighth", "three", "four", "one", "seven", "four", "six"]
+        let et6 = EncodedTokens(tokensByWhitespace: inputPhoneCardinal, encodedTokensByWhitespaceIndex: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], encoded: [])
         let parsedDigitsCardinal = try! parser.parse(tags: taggedInputPhoneCardinal, intent: metadata!.intents.filter({ $0.name == "inform.phone_number" }).first!, encoder: encoder!, encodedTokens: et6)
         XCTAssertEqual(parsedDigitsCardinal!["phone_number"]!.value as! String, "4238341746")
+        XCTAssertEqual(parsedDigitsCardinal!["phone_number"]!.rawValue!, inputPhoneCardinal.joined(separator: " "))
     }
     
     func testParseEntity() {

--- a/SpokestackTests/NLUTensorflowSlotParserTest.swift
+++ b/SpokestackTests/NLUTensorflowSlotParserTest.swift
@@ -86,7 +86,7 @@ class NLUTensorflowSlotParserTest: XCTestCase {
         let parsed = try! parser.parse(tags: taggedInput, intent: metadata!.intents.filter({ $0.name == "i.i" }).first!, encoder: encoder!, encodedTokens: et)
         XCTAssertNil(parsed!["iMi"]!.value)
         
-        // Slots declared by an intent but not tagged by the model are returned to the caller in the output with a null value
+        // Slots declared by an intent but not tagged by the model are returned to the caller in the output with a nil value
         let taggedInputEmpty = ["o", "o"]
         let parsedEmpty = try! parser.parse(tags: taggedInputEmpty, intent: metadata!.intents.filter({ $0.name == "i.i" }).first!, encoder: encoder!, encodedTokens: et)
         XCTAssertNil(parsedEmpty!["iMi"]!.value)

--- a/SpokestackTests/NLUTensorflowSlotParserTest.swift
+++ b/SpokestackTests/NLUTensorflowSlotParserTest.swift
@@ -79,6 +79,13 @@ class NLUTensorflowSlotParserTest: XCTestCase {
         XCTAssertEqual(parsedEntityO!["eponymous"]!.value as! String, "dead beef debug")
     }
     
+    func testParseUnspecifiedSlot() {
+        let taggedInput = ["o", "b_eponymous"]
+        let et = EncodedTokens(tokensByWhitespace: ["hey", "ma"], encodedTokensByWhitespaceIndex: [0, 1], encoded: [])
+        let parsed = try! parser.parse(tags: taggedInput, intent: metadata!.intents.filter({ $0.name == "i.i" }).first!, encoder: encoder!, encodedTokens: et)
+        XCTAssertNil(parsed)
+    }
+    
     func createMetadata() -> String {
         return #"""
         {


### PR DESCRIPTION
Does what it says on the tin. For example, "take a selfie" in ios-studio results in `NLUError.metadata("Could not find a slot called item in NLU model metadata.")`.