### PR TITLE
fix: update filter_audio dep to 0.5.0

### DIFF
--- a/Spokestack-iOS.podspec
+++ b/Spokestack-iOS.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/Spokestack/VAD/Wit', 'HEADER_SEARCH_PATHS' => '$(SRCROOT)/Spokestack/VAD/Wit'}
   s.preserve_paths = 'Spokestack/**/*.modulemap'
   s.public_header_files = 'Spokestack/Spokestack.h'
-  s.dependency 'TensorFlowLiteSwift', '~> 1.14.0', :modular_headers => true
+  s.dependency 'TensorFlowLiteSwift', '~> 1.14.0'
   s.dependency 'filter_audio', '~> 0.5.0'
   s.static_framework = true
 

--- a/Spokestack-iOS.podspec
+++ b/Spokestack-iOS.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'Spokestack-iOS'
   s.module_name = 'Spokestack'
-  s.version = '10.1.0'
+  s.version = '10.1.1'
   s.license = 'Apache'
   s.summary = 'Spokestack provides an extensible speech interface for the iOS platform.'
   s.homepage = 'https://www.spokestack.io'
@@ -16,8 +16,8 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/Spokestack/VAD/Wit', 'HEADER_SEARCH_PATHS' => '$(SRCROOT)/Spokestack/VAD/Wit'}
   s.preserve_paths = 'Spokestack/**/*.modulemap'
   s.public_header_files = 'Spokestack/Spokestack.h'
-  s.dependency 'TensorFlowLiteSwift', '~> 1.14.0'
-  s.dependency 'filter_audio', '~> 0.4.3'
+  s.dependency 'TensorFlowLiteSwift', '~> 1.14.0', :modular_headers => true
+  s.dependency 'filter_audio', '~> 0.5.0'
   s.static_framework = true
 
 end


### PR DESCRIPTION
 0.5.0 fixes the warning: `The Swift pod  depends upon , which does not define modules.` This also allows for clients to not declare `use_frameworks!` in their Podfile, and enables llvm to optimize Spokestack framework loading as a static library.