### PR TITLE
Speech pipeline stages are provided at initialization

### DIFF
--- a/Spokestack/SpeechConfiguration.swift
+++ b/Spokestack/SpeechConfiguration.swift
@@ -125,7 +125,4 @@ import Foundation
     @objc public var tracing: Trace.Level = Trace.Level.NONE
     /// Delegate events will be sent using the specified dispatch queue.
     @objc public var delegateDispatchQueue: DispatchQueue = DispatchQueue.global(qos: .userInitiated)
-    /// `SpeechProcessor` instances process audio frames from `AudioController`.
-    /// - SeeAlso: `AudioController`, `SpeechPipeline`, `SpeechContext`
-    public var stages: [SpeechProcessor] = []
 }

--- a/SpokestackTests/AppleSpeechRecognizerTest.swift
+++ b/SpokestackTests/AppleSpeechRecognizerTest.swift
@@ -40,8 +40,6 @@ class AppleSpeechRecognizerTest: XCTestCase {
         context.addListener(delegate)
         context.isActive = true
         context.isSpeech = true
-        configuration.stages = [asr]
-        asr.context = context
         asr.startStreaming()
         asr.process(Frame.silence(frameWidth: 10, sampleRate: 8000))
         asr.stopStreaming()

--- a/SpokestackTests/AppleWakewordRecognizerTest.swift
+++ b/SpokestackTests/AppleWakewordRecognizerTest.swift
@@ -34,7 +34,6 @@ class AppleWakewordRecognizerTest: XCTestCase {
         let configuration = SpeechConfiguration()
         let context = SpeechContext(configuration)
         let awr = AppleWakewordRecognizer(configuration, context: context)
-        configuration.stages = [awr]
         awr.context = context
         let delegate = AppleWakewordRecognizerTestDelegate()
         context.addListener(delegate)

--- a/SpokestackTests/AudioControllerTest.swift
+++ b/SpokestackTests/AudioControllerTest.swift
@@ -20,7 +20,6 @@ class AudioControllerTest: XCTestCase {
         controller.context = context
         let delegate = AudioControllerTestDelegate(config, context: context)
         context.addListener(delegate)
-        config.stages = [delegate]
         let setupFailedExpectation = expectation(description: "testStartStreaming calls AudioControllerTestDelegate as the result of failure method completion")
 
         // Uninitialized delegates do not cause an exception during startStreaming
@@ -35,7 +34,6 @@ class AudioControllerTest: XCTestCase {
         // Incompatible AVAudioSession category fails
         delegate.reset()
         context.addListener(delegate)
-        config.stages = [delegate]
         controller.context = context
         delegate.asyncExpectation = setupFailedExpectation
         XCTAssertNoThrow(try AVAudioSession.sharedInstance().setCategory(.ambient))
@@ -55,7 +53,6 @@ class AudioControllerTest: XCTestCase {
         controller.context = context
         let delegate = AudioControllerTestDelegate(config, context: context)
         context.addListener(delegate)
-        config.stages = [delegate]
         controller.stages = [delegate]
         let processFrameExpectation = expectation(description: "testStartStreaming calls AudioControllerTestDelegate as the result of processFrame method completion")
 


### PR DESCRIPTION
By the second line of working on the react-native client I realized that I had missed an easy simplification wrt speech pipeline stages. Removing stages from the config and requiring them in the public initializer of `SpeechPipeline` reduces both the client and library API while maintaining the equivalent level of flexibility for both internal stages and future 3rd-party stages.