### PR TITLE
restore objc interop for recognizers; fix double free bug in webtrcvad

### DIFF
--- a/Spokestack/AppleSpeechRecognizer.swift
+++ b/Spokestack/AppleSpeechRecognizer.swift
@@ -39,7 +39,7 @@ import Speech
         speechRecognizer.delegate = nil
     }
     
-    public init(_ configuration: SpeechConfiguration, context: SpeechContext) {
+    @objc public init(_ configuration: SpeechConfiguration, context: SpeechContext) {
         self.configuration = configuration
         self.context = context
         super.init()

--- a/Spokestack/AppleWakewordRecognizer.swift
+++ b/Spokestack/AppleWakewordRecognizer.swift
@@ -19,10 +19,10 @@ This pipeline component uses the Apple `SFSpeech` API to stream audio samples fo
     // MARK: Public properties
     
     /// Configuration for the recognizer.
-    public var configuration: SpeechConfiguration
+    @objc public var configuration: SpeechConfiguration
 
     /// Global state for the speech pipeline.
-    public var context: SpeechContext
+    @objc public var context: SpeechContext
     
     // MARK: Private properties
     
@@ -41,7 +41,7 @@ This pipeline component uses the Apple `SFSpeech` API to stream audio samples fo
         self.speechRecognizer.delegate = nil
     }
     
-    public init(_ configuration: SpeechConfiguration, context: SpeechContext) {
+    @objc public init(_ configuration: SpeechConfiguration, context: SpeechContext) {
         self.configuration = configuration
         self.context = context
         super.init()
@@ -164,12 +164,12 @@ This pipeline component uses the Apple `SFSpeech` API to stream audio samples fo
 extension AppleWakewordRecognizer: SpeechProcessor {
     
     /// Triggered by the speech pipeline, instructing the recognizer to begin streaming and processing audio.
-    public func startStreaming() {
+    @objc public func startStreaming() {
         self.prepare()
     }
     
     /// Triggered by the speech pipeline, instructing the recognizer to stop streaming audio and complete processing.
-    public func stopStreaming() {
+    @objc public func stopStreaming() {
         self.stopRecognition()
         self.dispatchWorker?.cancel()
         self.dispatchWorker = nil
@@ -181,7 +181,7 @@ extension AppleWakewordRecognizer: SpeechProcessor {
     ///
     /// Processes audio in an async thread.
     /// - Parameter frame: Frame of audio samples.
-    public func process(_ frame: Data) -> Void {
+    @objc public func process(_ frame: Data) -> Void {
         if !self.recognitionTaskRunning && self.context.isSpeech && !self.context.isActive {
             self.startRecognition()
         } else if context.isActive {

--- a/Spokestack/SpeechContext.swift
+++ b/Spokestack/SpeechContext.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// This class maintains global state for the speech pipeline, allowing pipeline components to communicate information among themselves and event handlers.
 @objc public class SpeechContext: NSObject {
-    public var configuration: SpeechConfiguration
+    @objc public var configuration: SpeechConfiguration
     /// Current speech transcript
     @objc public var transcript: String = ""
     /// Current speech recognition confidence: [0-1)

--- a/Spokestack/SpeechPipeline.swift
+++ b/Spokestack/SpeechPipeline.swift
@@ -22,9 +22,9 @@ import Dispatch
     // MARK: Public (properties)
     
     /// Pipeline configuration parameters.
-    public private (set) var configuration: SpeechConfiguration
+    @objc public private (set) var configuration: SpeechConfiguration
     /// Global state for the speech pipeline.
-    public let context: SpeechContext
+    @objc public let context: SpeechContext
     
     
     // MARK: Private (properties)

--- a/Spokestack/SpeechProcessor.swift
+++ b/Spokestack/SpeechProcessor.swift
@@ -14,21 +14,21 @@ import Foundation
 @objc public protocol SpeechProcessor: AnyObject {
     
     /// The global configuration for all speech pipeline components.
-    var configuration: SpeechConfiguration { get set }
+    @objc var configuration: SpeechConfiguration { get set }
     
     /// Global speech context.
-    var context: SpeechContext { get set }
+    @objc var context: SpeechContext { get set }
     
     /// Trigger from the speech pipeline for the component to begin processing the audio stream.
     /// - Parameter context: The current speech context.
-    func startStreaming() -> Void
+    @objc func startStreaming() -> Void
     
     /// Trigger from the speech pipeline for the component to stop processing the audio stream.
-    func stopStreaming() -> Void
+    @objc func stopStreaming() -> Void
     
     /// Receives a frame of audio samples for processing. Interface between the `SpeechProcessor` and `AudioController` components.
     /// - Parameter frame: Audio frame of samples.
-    func process(_ frame: Data) -> Void
+    @objc func process(_ frame: Data) -> Void
 }
 
 /// Convenience enum for the singletons of the different implementers of the `SpeechProcessor` protocol.

--- a/Spokestack/TFLiteWakewordRecognizer.swift
+++ b/Spokestack/TFLiteWakewordRecognizer.swift
@@ -29,10 +29,10 @@ import TensorFlowLite
     // MARK: Public (properties)
     
     /// Configuration for the recognizer.
-    public var configuration: SpeechConfiguration
+    @objc public var configuration: SpeechConfiguration
     
     /// Global state for the speech pipeline.
-    public var context: SpeechContext
+    @objc public var context: SpeechContext
     
     // MARK: Private (properties)
     
@@ -94,7 +94,7 @@ import TensorFlowLite
     deinit {
     }
     
-    public init(_ configuration: SpeechConfiguration, context: SpeechContext) {
+    @objc public init(_ configuration: SpeechConfiguration, context: SpeechContext) {
         self.configuration = configuration
         self.context = context
         super.init()
@@ -422,12 +422,12 @@ import TensorFlowLite
 extension TFLiteWakewordRecognizer : SpeechProcessor {
     
     /// Triggered by the speech pipeline, instructing the recognizer to begin streaming and processing audio.
-    public func startStreaming() -> Void {
+    @objc public func startStreaming() -> Void {
         self.active = true
     }
     
     /// Triggered by the speech pipeline, instructing the recognizer to stop streaming audio and complete processing.
-    public func stopStreaming() -> Void {
+    @objc public func stopStreaming() -> Void {
         self.active = false
     }
     
@@ -435,7 +435,7 @@ extension TFLiteWakewordRecognizer : SpeechProcessor {
     ///
     /// Processes audio in an async thread.
     /// - Parameter frame: Frame of audio samples.
-    public func process(_ frame: Data) -> Void {
+    @objc public func process(_ frame: Data) -> Void {
         audioProcessingQueue.async {[weak self] in
             guard let strongSelf = self else { return }
             if !strongSelf.context.isActive {

--- a/Spokestack/VADTrigger.swift
+++ b/Spokestack/VADTrigger.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 @objc public class VADTrigger: NSObject, SpeechProcessor {
-    public var configuration: SpeechConfiguration
+    @objc public var configuration: SpeechConfiguration
     
-    public var context: SpeechContext
+    @objc public var context: SpeechContext
     
     @objc public init(_ configuration: SpeechConfiguration, context: SpeechContext) {
         self.configuration = configuration
@@ -19,11 +19,11 @@ import Foundation
         super.init()
     }
     
-    public func startStreaming() {}
+    @objc public func startStreaming() {}
     
-    public func stopStreaming() {}
+    @objc public func stopStreaming() {}
     
-    public func process(_ frame: Data) {
+    @objc public func process(_ frame: Data) {
         if self.context.isSpeech && !self.context.isActive {
             self.context.isActive = true
             self.context.dispatch(.activate)

--- a/Spokestack/WebRTCVAD.swift
+++ b/Spokestack/WebRTCVAD.swift
@@ -55,7 +55,6 @@ private var frameBuffer: RingBuffer<Int16>!
     
     deinit {
         vad.deinitialize(count: 1)
-        WebRtcVad_Free(vad.pointee)
     }
     
     /// Creates and configures a new WebRTC VAD component.

--- a/SpokestackTests/SpeechPipelineTest.swift
+++ b/SpokestackTests/SpeechPipelineTest.swift
@@ -20,7 +20,7 @@ class SpeechPipelineTest: XCTestCase {
         let config = SpeechConfiguration()
 
         // successful init calls didInit
-        _ = SpeechPipeline(configuration: config, listeners: [delegate], stages: [])
+        let p = SpeechPipeline(configuration: config, listeners: [delegate], stages: [])
         wait(for: [didInitExpectation], timeout: 1)
         XCTAssert(delegate.didDidInit)
     }
@@ -153,7 +153,7 @@ class SpeechPipelineBuilderTest: XCTestCase {
 
         // a profile is requred
         XCTAssertThrowsError(try SpeechPipelineBuilder().addListener(delegate).build())
-        
+
         // tflite
         delegate.asyncExpectation = didInit1Expectation
         let _ = try! SpeechPipelineBuilder()
@@ -164,7 +164,7 @@ class SpeechPipelineBuilderTest: XCTestCase {
         wait(for: [didInit1Expectation], timeout: 1)
         XCTAssert(compare(expected: e1, actual: AudioController.sharedInstance.stages))
 
-        
+
         // appleWW
         delegate.reset()
         let wakeActiveMax = 10000
@@ -172,10 +172,8 @@ class SpeechPipelineBuilderTest: XCTestCase {
             .useProfile(.appleWakewordAppleSpeech)
             .setProperty("wakeActiveMax", wakeActiveMax.description)
             .build()
-        let e2 = [WebRTCVAD.self, AppleWakewordRecognizer.self, AppleSpeechRecognizer.self]
         XCTAssertEqual(wakeActiveMax, p2.configuration.wakeActiveMax)
-        XCTAssert(compare(expected: e2, actual: AudioController.sharedInstance.stages))
-
+        XCTAssert(compare(expected: [WebRTCVAD.self, AppleWakewordRecognizer.self, AppleSpeechRecognizer.self], actual: AudioController.sharedInstance.stages))
 
         // vadTrigger
         delegate.reset()

--- a/SpokestackTests/SpeechPipelineTest.swift
+++ b/SpokestackTests/SpeechPipelineTest.swift
@@ -20,7 +20,7 @@ class SpeechPipelineTest: XCTestCase {
         let config = SpeechConfiguration()
 
         // successful init calls didInit
-        let p = SpeechPipeline(configuration: config, listeners: [delegate], stages: [])
+        _ = SpeechPipeline(configuration: config, listeners: [delegate], stages: [])
         wait(for: [didInitExpectation], timeout: 1)
         XCTAssert(delegate.didDidInit)
     }


### PR DESCRIPTION
The 11.0 release inadvertently removed some `@objc` attributes.