### PR TITLE
SpeechContext is required in the SpeechPipeline stages constructor

### DIFF
--- a/Spokestack/SpeechContext.swift
+++ b/Spokestack/SpeechContext.swift
@@ -35,7 +35,7 @@ import Foundation
     /// Adds the specified listener instance to the ordered set of listeners. The specified listener instance may only be added once; duplicates will be ignored. The specified listener will recieve speech pipeline events.
     ///
     /// - Parameter listener: The listener to add.
-    @objc public func addListener(_ listener: SpeechEventListener) {
+    @objc internal func addListener(_ listener: SpeechEventListener) {
         if !self.listeners.contains(where: { l in
             return listener === l ? true : false
         }) {
@@ -45,14 +45,14 @@ import Foundation
     
     /// Removes the specified listener by reference. The specified listener will no longer recieve speech pipeline events.
     /// - Parameter listener: The listener to remove.
-    @objc public func removeListener(_ listener: SpeechEventListener) {
+    @objc internal func removeListener(_ listener: SpeechEventListener) {
         for (i, l) in self.listeners.enumerated() {
             _ = listener === l ? self.listeners.remove(at: i) : nil
         }
     }
     
     /// Removes all listeners.
-    @objc public func removeListeners() {
+    @objc internal func removeListeners() {
         self.listeners = []
     }
 

--- a/Spokestack/SpeechPipeline.swift
+++ b/Spokestack/SpeechPipeline.swift
@@ -46,9 +46,9 @@ import Dispatch
     /// - Parameter configuration: Configuration parameters for the speech pipeline.
     /// - Parameter listeners: Delegate implementations of `SpeechEventListener` that receive speech pipeline events.
     /// - Parameter stages: `SpeechProcessor` instances process audio frames from `AudioController`.
-    @objc public init(configuration: SpeechConfiguration, listeners: [SpeechEventListener], stages: [SpeechProcessor]) {
+    @objc public init(configuration: SpeechConfiguration, listeners: [SpeechEventListener], stages: [SpeechProcessor], context: SpeechContext) {
         self.configuration = configuration
-        self.context = SpeechContext(configuration)
+        self.context = context
         self.stages = stages
         AudioController.sharedInstance.configuration = configuration
         AudioController.sharedInstance.context = self.context


### PR DESCRIPTION
Fixes a circular reference problem when a client does not use profiles + constructs stages (which is required when not using profiles). The pipeline creates its own `SpeechContext` instance, which will be different than the context used in stages. Since the pipeline now takes in the `SpeechContext` in this usage, there is no longer a need for the context to manage listeners, so `add`/`remove` for listeners has been rescoped to `internal`. The new test case is included to catch the bug that the circular constructor causes: a stage calls `dispatch` to a context with no listeners.