### PR TITLE
Fix for Apple ASR sending two recognize events + tflite wakeword encoder improvements

### DIFF
--- a/Spokestack/TFLiteWakewordRecognizer.swift
+++ b/Spokestack/TFLiteWakewordRecognizer.swift
@@ -180,7 +180,7 @@ import TensorFlowLite
         self.encodeWidth = c.encodeWidth
         self.encodeLength = c.encodeLength * c.sampleRate / 1000 / self.hopLength
         self.stateWidth = c.stateWidth
-        self.encodeWindow = RingBuffer(self.encodeLength * c.encodeWidth, repeating: 0.0)
+        self.encodeWindow = RingBuffer(self.encodeLength * c.encodeWidth, repeating: -1.0)
         self.encodeState = RingBuffer(c.stateWidth, repeating: 0.0)
         self.encodeState.fill(0.0)
         self.detectWindow = RingBuffer(self.encodeLength * c.encodeWidth, repeating: 0.0)
@@ -393,7 +393,7 @@ import TensorFlowLite
         
         // Reset and fill the other buffers, which prevents them from lagging the detection
         self.frameWindow.reset().fill(0)
-        self.encodeWindow.reset().fill(0)
+        self.encodeWindow.reset().fill(-1.0)
         self.encodeState.reset().fill(0)
         self.detectWindow.reset().fill(0)
         


### PR DESCRIPTION
- Because the `DispatchQueue` is set after the recognize event is sent, it will get called again after the VAD timeout length. However, the ASR callback can be stopped executing if the deactivated state has already been entered.
- ios equivalent of https://github.com/spokestack/spokestack-android/pull/98