### PR TITLE
move VAD edge detection from wakeword recognizer to vad

### DIFF
--- a/Spokestack.xcodeproj/project.pbxproj
+++ b/Spokestack.xcodeproj/project.pbxproj
@@ -318,7 +318,6 @@
 			isa = PBXGroup;
 			children = (
 				59FB0C8922AEE4DA00FB9662 /* Extensions */,
-				59062EFD22A5AA6C00613AD8 /* VAD */,
 				01D31F60216BAF9A0055FD45 /* Controllers */,
 				01D31F64216BAFAA0055FD45 /* Errors */,
 				01D31F68216BAFBC0055FD45 /* Managers */,
@@ -426,6 +425,7 @@
 				59365947220889EE00C0365F /* AppleWakewordRecognizer.swift */,
 				594154B722F8AD2200E3624E /* TFLiteWakewordRecognizer.swift */,
 				59416CCC24B5359F009B9304 /* VADTrigger.swift */,
+				59C15D52234D322A00B091F4 /* WebRTCVAD.swift */,
 			);
 			name = Recognizers;
 			sourceTree = "<group>";
@@ -444,14 +444,6 @@
 				01D31F8D216BB0370055FD45 /* Typealiases.swift */,
 			);
 			name = Typealiases;
-			sourceTree = "<group>";
-		};
-		59062EFD22A5AA6C00613AD8 /* VAD */ = {
-			isa = PBXGroup;
-			children = (
-				59C15D51234D321A00B091F4 /* filter_audio */,
-			);
-			path = VAD;
 			sourceTree = "<group>";
 		};
 		59062F0822A5AA8400613AD8 /* Frameworks */ = {
@@ -485,14 +477,6 @@
 				01D972BB23C592A00002FF79 /* TextToSpeechResult.swift */,
 			);
 			name = TTS;
-			sourceTree = "<group>";
-		};
-		59C15D51234D321A00B091F4 /* filter_audio */ = {
-			isa = PBXGroup;
-			children = (
-				59C15D52234D322A00B091F4 /* WebRTCVAD.swift */,
-			);
-			name = filter_audio;
 			sourceTree = "<group>";
 		};
 		59FB0C8922AEE4DA00FB9662 /* Extensions */ = {

--- a/Spokestack/AppleSpeechRecognizer.swift
+++ b/Spokestack/AppleSpeechRecognizer.swift
@@ -43,7 +43,7 @@ import Speech
     
     /// Initializes a AppleSpeechRecognizer instance.
     ///
-    /// A recognizer is initialzed by, and recieves `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
+    /// A recognizer is initialized by, and receives `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
     ///
     /// The AppleSpeechRecognizer receives audio data frames to `process` from a tap into the system `AudioEngine`.
     /// - Parameters:

--- a/Spokestack/AppleSpeechRecognizer.swift
+++ b/Spokestack/AppleSpeechRecognizer.swift
@@ -41,6 +41,14 @@ import Speech
         speechRecognizer.delegate = nil
     }
     
+    /// Initializes a AppleSpeechRecognizer instance.
+    ///
+    /// A recognizer is initialzed by, and recieves `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
+    ///
+    /// The AppleSpeechRecognizer receives audio data frames to `process` from a tap into the system `AudioEngine`.
+    /// - Parameters:
+    ///   - configuration: Configuration for the recognizer.
+    ///   - context: Global state for the speech pipeline.
     @objc public init(_ configuration: SpeechConfiguration, context: SpeechContext) {
         self.configuration = configuration
         self.context = context
@@ -164,10 +172,11 @@ import Speech
 }
 
 extension AppleSpeechRecognizer: SpeechProcessor {
+    
     /// Triggered by the speech pipeline, instructing the recognizer to begin streaming and processing audio.
     @objc public func startStreaming() {
     }
-    
+
     /// Triggered by the speech pipeline, instructing the recognizer to stop streaming audio and complete processing.
     @objc public func stopStreaming() {
         if self.isActive {
@@ -178,7 +187,9 @@ extension AppleSpeechRecognizer: SpeechProcessor {
             self.recognitionRequest = nil
         }
     }
-    
+
+    /// Processes an audio frame, detecting speech.
+    /// - Parameter frame: Audio frame of samples.
     @objc public func process(_ frame: Data) {
         if self.context.isActive {
             if !self.isActive {

--- a/Spokestack/AppleSpeechRecognizer.swift
+++ b/Spokestack/AppleSpeechRecognizer.swift
@@ -190,7 +190,7 @@ extension AppleSpeechRecognizer: SpeechProcessor {
 
     /// Processes an audio frame, recognizing speech.
     /// - Note: Processes audio in an async thread.
-    /// - Remark: The Apple ASR hooks up directly to it's own audio tap for processing audio frames. When the `AudioController` calls this `process`, it checks to see if the pipeline is activated, and if so kicks off it's own VAD and ASR independently of any other components in the speech pipeline.
+    /// - Remark: The Apple ASR hooks up directly to its own audio tap for processing audio frames. When the `AudioController` calls this `process`, it checks to see if the pipeline is activated, and if so kicks off its own VAD and ASR independently of any other components in the speech pipeline.
     /// - Parameter frame: Audio frame of samples.
     @objc public func process(_ frame: Data) {
         if self.context.isActive {

--- a/Spokestack/AppleSpeechRecognizer.swift
+++ b/Spokestack/AppleSpeechRecognizer.swift
@@ -188,7 +188,9 @@ extension AppleSpeechRecognizer: SpeechProcessor {
         }
     }
 
-    /// Processes an audio frame, detecting speech.
+    /// Processes an audio frame, recognizing speech.
+    /// - Note: Processes audio in an async thread.
+    /// - Remark: The Apple ASR hooks up directly to it's own audio tap for processing audio frames. When the `AudioController` calls this `process`, it checks to see if the pipeline is activated, and if so kicks off it's own VAD and ASR independently of any other components in the speech pipeline.
     /// - Parameter frame: Audio frame of samples.
     @objc public func process(_ frame: Data) {
         if self.context.isActive {

--- a/Spokestack/AppleWakewordRecognizer.swift
+++ b/Spokestack/AppleWakewordRecognizer.swift
@@ -43,7 +43,7 @@ This pipeline component uses the Apple `SFSpeech` API to stream audio samples fo
     
     /// Initializes a AppleWakewordRecognizer instance.
     ///
-    /// A recognizer is initialzed by, and recieves `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
+    /// A recognizer is initialized by, and receives `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
     ///
     /// The AppleWakewordRecognizer receives audio data frames to `process` from a tap into the system `AudioEngine`.
     /// - Parameters:

--- a/Spokestack/AppleWakewordRecognizer.swift
+++ b/Spokestack/AppleWakewordRecognizer.swift
@@ -185,9 +185,9 @@ extension AppleWakewordRecognizer: SpeechProcessor {
         self.audioEngine.inputNode.removeTap(onBus: 0)
     }
     
-    /// Receives a frame of audio samples for processing. Interface between the `SpeechProcessor` and `AudioController` components.
-    ///
-    /// Processes audio in an async thread.
+    /// Receives a frame of audio samples for processing. Interface between the `SpeechProcessor` and `AudioController` components. Processes audio in an async thread.
+    /// - Note: Processes audio in an async thread.
+    /// - Remark: The Apple Wakeword Recognizer hooks up directly to it's own audio tap for processing audio frames. When the `AudioController` calls this `process`, it checks to see if the pipeline has detected speech, and if so kicks off it's own VAD and wakeword recgonizer independently of any other components in the speech pipeline.
     /// - Parameter frame: Frame of audio samples.
     @objc public func process(_ frame: Data) -> Void {
         if !self.recognitionTaskRunning && self.context.isSpeech && !self.context.isActive {

--- a/Spokestack/AppleWakewordRecognizer.swift
+++ b/Spokestack/AppleWakewordRecognizer.swift
@@ -41,6 +41,14 @@ This pipeline component uses the Apple `SFSpeech` API to stream audio samples fo
         self.speechRecognizer.delegate = nil
     }
     
+    /// Initializes a AppleWakewordRecognizer instance.
+    ///
+    /// A recognizer is initialzed by, and recieves `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
+    ///
+    /// The AppleWakewordRecognizer receives audio data frames to `process` from a tap into the system `AudioEngine`.
+    /// - Parameters:
+    ///   - configuration: Configuration for the recognizer.
+    ///   - context: Global state for the speech pipeline.
     @objc public init(_ configuration: SpeechConfiguration, context: SpeechContext) {
         self.configuration = configuration
         self.context = context

--- a/Spokestack/AppleWakewordRecognizer.swift
+++ b/Spokestack/AppleWakewordRecognizer.swift
@@ -187,7 +187,7 @@ extension AppleWakewordRecognizer: SpeechProcessor {
     
     /// Receives a frame of audio samples for processing. Interface between the `SpeechProcessor` and `AudioController` components. Processes audio in an async thread.
     /// - Note: Processes audio in an async thread.
-    /// - Remark: The Apple Wakeword Recognizer hooks up directly to it's own audio tap for processing audio frames. When the `AudioController` calls this `process`, it checks to see if the pipeline has detected speech, and if so kicks off it's own VAD and wakeword recgonizer independently of any other components in the speech pipeline.
+    /// - Remark: The Apple Wakeword Recognizer hooks up directly to its own audio tap for processing audio frames. When the `AudioController` calls this `process`, it checks to see if the pipeline has detected speech, and if so kicks off its own VAD and wakeword recognizer independently of any other components in the speech pipeline.
     /// - Parameter frame: Frame of audio samples.
     @objc public func process(_ frame: Data) -> Void {
         if !self.recognitionTaskRunning && self.context.isSpeech && !self.context.isActive {

--- a/Spokestack/SpeechConfiguration.swift
+++ b/Spokestack/SpeechConfiguration.swift
@@ -24,7 +24,7 @@ import Foundation
     @objc public var rmsTarget: Float = 0.08
     /// The Exponentially Weighted Moving Average (EWMA) update rate for the current  Root Mean Squared (RMS) signal energy (0 for no RMS normalization).
     /// - SeeAlso: `TFLiteWakewordRecognizer`
-    @objc public var rmsAlpha: Float = 0.1
+    @objc public var rmsAlpha: Float = 0.0
     /// The size of the signal window used to calculate the STFT, in number of samples - should be a power of 2 for maximum efficiency.
     /// - SeeAlso: `TFLiteWakewordRecognizer`
     @objc public var fftWindowSize: Int = 512
@@ -49,7 +49,7 @@ import Foundation
     @objc public var encodeLength: Int = 1000
     /// The threshold of the wakeword recognizer classifier's posterior output, above which the wakeword recognizer activates the pipeline, in the range [0, 1].
     /// - SeeAlso: `TFLiteWakewordRecognizer`
-    @objc public var wakeThreshold: Float = 0.9
+    @objc public var wakeThreshold: Float = 0.8
     /// The minimum length of an activation, in milliseconds. Used to ignore a Voice Activity Detector (VAD) deactivation after the wakeword.
     /// - SeeAlso: TFLiteWakewordRecognizer`
     @objc public var wakeActiveMin: Int = 2000

--- a/Spokestack/TFLiteWakewordRecognizer.swift
+++ b/Spokestack/TFLiteWakewordRecognizer.swift
@@ -93,7 +93,7 @@ import TensorFlowLite
     
     /// Initializes a TFLiteWakewordRecognizer instance.
     ///
-    /// A recognizer is initialzed by, and recieves `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
+    /// A recognizer is initialized by, and receives `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
     ///
     /// The TFLiteWakewordRecognizer receives audio data frames to `process` from `AudioController`.
     /// - Parameters:

--- a/Spokestack/TFLiteWakewordRecognizer.swift
+++ b/Spokestack/TFLiteWakewordRecognizer.swift
@@ -91,6 +91,14 @@ import TensorFlowLite
     deinit {
     }
     
+    /// Initializes a TFLiteWakewordRecognizer instance.
+    ///
+    /// A recognizer is initialzed by, and recieves `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
+    ///
+    /// The TFLiteWakewordRecognizer receives audio data frames to `process` from `AudioController`.
+    /// - Parameters:
+    ///   - configuration: Configuration for the recognizer.
+    ///   - context: Global state for the speech pipeline.
     @objc public init(_ configuration: SpeechConfiguration, context: SpeechContext) {
         self.configuration = configuration
         self.context = context

--- a/Spokestack/TFLiteWakewordRecognizer.swift
+++ b/Spokestack/TFLiteWakewordRecognizer.swift
@@ -42,10 +42,7 @@ import TensorFlowLite
     }
     
     // Wakeword Activation Management
-    internal var activeLength: Int = 0
-    private var minActive: Int = 0
-    private var maxActive: Int = 0
-    private var active: Bool = false
+    private var isSpeechDetected: Bool = false
     
     // TensorFlowLite models
     private var filterModel: Interpreter?
@@ -188,11 +185,6 @@ import TensorFlowLite
         // attention model posteriors
         self.posteriorThreshold = c.wakeThreshold
         self.posteriorMax = 0
-        
-        // Wakeword activation lengths
-        let frameWidth: Int = c.frameWidth
-        self.minActive = c.wakeActiveMin / frameWidth
-        self.maxActive = c.wakeActiveMax / frameWidth
     }
     
     // MARK: Audio processing
@@ -401,7 +393,7 @@ import TensorFlowLite
         self.posteriorMax = 0
         
         // control flow deactivation
-        self.activeLength = 0
+        self.isSpeechDetected = false
     }
     
     private func debug() -> Void {
@@ -422,13 +414,11 @@ import TensorFlowLite
 extension TFLiteWakewordRecognizer : SpeechProcessor {
     
     /// Triggered by the speech pipeline, instructing the recognizer to begin streaming and processing audio.
-    @objc public func startStreaming() -> Void {
-        self.active = true
-    }
+    @objc public func startStreaming() -> Void {}
     
     /// Triggered by the speech pipeline, instructing the recognizer to stop streaming audio and complete processing.
     @objc public func stopStreaming() -> Void {
-        self.active = false
+        self.isSpeechDetected = false
     }
     
     /// Receives a frame of audio samples for processing. Interface between the `SpeechProcessor` and `AudioController` components.
@@ -439,18 +429,11 @@ extension TFLiteWakewordRecognizer : SpeechProcessor {
         audioProcessingQueue.async {[weak self] in
             guard let strongSelf = self else { return }
             if !strongSelf.context.isActive {
-                if (strongSelf.context.isSpeech &&
-                    // don't exceed max activation length
-                    strongSelf.activeLength <= strongSelf.maxActive)
-                    ||
-                    // don't deactivate if vad previously detected speech and the min activation length hasn't been met
-                    (strongSelf.active &&
-                        strongSelf.activeLength <= strongSelf.minActive) {
+                if strongSelf.context.isSpeech {
                     // Run the current frame through the detector pipeline.
                     // Activate the pipeline if a keyword phrase was detected.
                     do {
-                        strongSelf.active = true
-                        strongSelf.activeLength += 1
+                        strongSelf.isSpeechDetected = true
                         // Decode the FFT outputs into the filter model's input
                         try strongSelf.sample(frame)
                         let activate = try strongSelf.detect()
@@ -464,10 +447,9 @@ extension TFLiteWakewordRecognizer : SpeechProcessor {
                         strongSelf.context.error = error
                         strongSelf.context.dispatch(.error)
                     }
-                // activation edge
-                } else if strongSelf.active {
+                // vad detection edge
+                } else if strongSelf.isSpeechDetected {
                     strongSelf.reset()
-                    strongSelf.active = false
                 }
             }
         }

--- a/Spokestack/Trace.swift
+++ b/Spokestack/Trace.swift
@@ -88,8 +88,6 @@ public struct Trace {
                     handle.seekToEndOfFile()
                     handle.write(data)
                     handle.synchronizeFile()
-                    context?.trace = "Trace spit appended \(data.count) to: \(path.path)"
-                    context?.dispatch(.trace)
                 } catch let error {
                     context?.trace = "Trace spit failed to open a handle to \(path.path) because \(error)"
                     context?.dispatch(.trace)

--- a/Spokestack/VADTrigger.swift
+++ b/Spokestack/VADTrigger.swift
@@ -9,20 +9,34 @@
 import Foundation
 
 @objc public class VADTrigger: NSObject, SpeechProcessor {
+
+    /// Configuration for the recognizer.
     @objc public var configuration: SpeechConfiguration
-    
+    /// Global state for the speech pipeline.
     @objc public var context: SpeechContext
-    
+
+    /// Initializes a VADTrigger instance.
+    ///
+    /// A recognizer is initialzed by, and recieves `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
+    ///
+    /// The VADTrigger receives audio data frames to `process` from `AudioController`.
+    /// - Parameters:
+    ///   - configuration: Configuration for the recognizer.
+    ///   - context: Global state for the speech pipeline.
     @objc public init(_ configuration: SpeechConfiguration, context: SpeechContext) {
         self.configuration = configuration
         self.context = context
         super.init()
     }
-    
+
+    /// Triggered by the speech pipeline, instructing the recognizer to begin streaming and processing audio.
     @objc public func startStreaming() {}
-    
+
+    /// Triggered by the speech pipeline, instructing the recognizer to stop streaming audio and complete processing.
     @objc public func stopStreaming() {}
-    
+
+    /// Processes an audio frame, activating the pipeline if speech is detected.
+    /// - Parameter frame: Audio frame of samples.
     @objc public func process(_ frame: Data) {
         if self.context.isSpeech && !self.context.isActive {
             self.context.isActive = true

--- a/Spokestack/VADTrigger.swift
+++ b/Spokestack/VADTrigger.swift
@@ -10,14 +10,14 @@ import Foundation
 
 @objc public class VADTrigger: NSObject, SpeechProcessor {
 
-    /// Configuration for the recognizer.
+    /// Configuration for the trigger.
     @objc public var configuration: SpeechConfiguration
     /// Global state for the speech pipeline.
     @objc public var context: SpeechContext
 
     /// Initializes a VADTrigger instance.
     ///
-    /// A recognizer is initialzed by, and recieves `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
+    /// A wakeword trigger is initialized by, and receives `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
     ///
     /// The VADTrigger receives audio data frames to `process` from `AudioController`.
     /// - Parameters:
@@ -29,10 +29,10 @@ import Foundation
         super.init()
     }
 
-    /// Triggered by the speech pipeline, instructing the recognizer to begin streaming and processing audio.
+    /// Triggered by the speech pipeline, instructing the trigger to begin streaming and processing audio.
     @objc public func startStreaming() {}
 
-    /// Triggered by the speech pipeline, instructing the recognizer to stop streaming audio and complete processing.
+    /// Triggered by the speech pipeline, instructing the trigger to stop streaming audio and complete processing.
     @objc public func stopStreaming() {}
 
     /// Processes an audio frame, activating the pipeline if speech is detected.

--- a/Spokestack/VADTrigger.swift
+++ b/Spokestack/VADTrigger.swift
@@ -15,11 +15,7 @@ import Foundation
     /// Global state for the speech pipeline.
     @objc public var context: SpeechContext
 
-    /// Initializes a VADTrigger instance.
-    ///
-    /// A wakeword trigger is initialized by, and receives `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
-    ///
-    /// The VADTrigger receives audio data frames to `process` from `AudioController`.
+    /// Initializes a VADTrigger instance. A wakeword trigger is initialized by, and receives `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`. The VADTrigger receives audio data frames to `process` from `AudioController`.
     /// - Parameters:
     ///   - configuration: Configuration for the recognizer.
     ///   - context: Global state for the speech pipeline.

--- a/Spokestack/WebRTCVAD.swift
+++ b/Spokestack/WebRTCVAD.swift
@@ -32,7 +32,7 @@ private var frameBuffer: RingBuffer<Int16>!
 /// Swift wrapper for WebRTC's voice activity detector.
 @objc public class WebRTCVAD: NSObject, SpeechProcessor {
 
-    /// Configuration for the recognizer.
+    /// Configuration for the detector.
     @objc public var configuration: SpeechConfiguration
     /// Global state for the speech pipeline.
     @objc public var context: SpeechContext
@@ -43,19 +43,19 @@ private var frameBuffer: RingBuffer<Int16>!
     private var maxDetectionLength: Int = 0
     private var isSpeechDetected: Bool = false
 
-    /// Triggered by the speech pipeline, instructing the recognizer to begin streaming and processing audio.
+    /// Triggered by the speech pipeline, instructing the detector to begin streaming and processing audio.
     @objc public func startStreaming() {}
 
-    /// Triggered by the speech pipeline, instructing the recognizer to stop streaming audio and complete processing.
+    /// Triggered by the speech pipeline, instructing the detector to stop streaming audio and complete processing.
     @objc public func stopStreaming() {}
 
     /// Initializes a WebRTCVAD instance.
     ///
-    /// A recognizer is initialzed by, and recieves `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
+    /// A recognizer is initialized by, and receives `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
     ///
     /// The WebRTCVAD receives audio data frames to `process` from `AudioController`.
     /// - Parameters:
-    ///   - configuration: Configuration for the recognizer.
+    ///   - configuration: Configuration for the detector.
     ///   - context: Global state for the speech pipeline.
     @objc public init(_ configuration: SpeechConfiguration, context: SpeechContext) {
         self.configuration = configuration

--- a/Spokestack/WebRTCVAD.swift
+++ b/Spokestack/WebRTCVAD.swift
@@ -31,29 +31,32 @@ private var frameBuffer: RingBuffer<Int16>!
 
 /// Swift wrapper for WebRTC's voice activity detector.
 @objc public class WebRTCVAD: NSObject, SpeechProcessor {
-    
-    /// <#Description#>
+
+    /// Configuration for the recognizer.
     @objc public var configuration: SpeechConfiguration
-    
-    /// <#Description#>
+    /// Global state for the speech pipeline.
     @objc public var context: SpeechContext
-    
+
     // vad detection length management
     private var detectionLength: Int = 0
     private var minDetectionLength: Int = 0
     private var maxDetectionLength: Int = 0
     private var isSpeechDetected: Bool = false
-    
-    /// <#Description#>
+
+    /// Triggered by the speech pipeline, instructing the recognizer to begin streaming and processing audio.
     @objc public func startStreaming() {}
-    
-    /// <#Description#>
+
+    /// Triggered by the speech pipeline, instructing the recognizer to stop streaming audio and complete processing.
     @objc public func stopStreaming() {}
-    
-    /// <#Description#>
+
+    /// Initializes a WebRTCVAD instance.
+    ///
+    /// A recognizer is initialzed by, and recieves `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
+    ///
+    /// The WebRTCVAD receives audio data frames to `process` from `AudioController`.
     /// - Parameters:
-    ///   - configuration: <#configuration description#>
-    ///   - context: <#context description#>
+    ///   - configuration: Configuration for the recognizer.
+    ///   - context: Global state for the speech pipeline.
     @objc public init(_ configuration: SpeechConfiguration, context: SpeechContext) {
         self.configuration = configuration
         self.context = context
@@ -118,8 +121,6 @@ private var frameBuffer: RingBuffer<Int16>!
     
     /// Processes an audio frame, detecting speech.
     /// - Parameter frame: Audio frame of samples.
-    ///
-    /// - Throws: RingBufferStateError.illegalState if the frame buffer enters an invalid state
     @objc public func process(_ frame: Data) -> Void {
         do {
             var detected: Bool = false

--- a/SpokestackTests/TFLiteWakewordRecognizerTest.swift
+++ b/SpokestackTests/TFLiteWakewordRecognizerTest.swift
@@ -95,6 +95,7 @@ class TFLiteWakewordRecognizerTest: XCTestCase {
         // setup
         self.tflwr?.context.addListener(self.delegate)
         self.tflwr?.context.isActive = false
+        self.tflwr?.context.isSpeech = true
         self.tflwr?.startStreaming()
         let activateExpectation = XCTestExpectation(description: "process without failure.")
         let deactivateMaxActiveExpectation = XCTestExpectation(description: "process without failure.")
@@ -115,7 +116,6 @@ class TFLiteWakewordRecognizerTest: XCTestCase {
         self.tflwr?.startStreaming()
         self.tflwr?.context.isSpeech = true
         self.tflwr?.context.isActive = false
-        self.tflwr?.activeLength = 10
         self.delegate.didDeactivateExpectation = deactivateMaxActiveExpectation
         self.delegate.didActivateExpectation = activateExpectation
         for _ in 0...1 {

--- a/SpokestackTests/WebRTCVADTest.swift
+++ b/SpokestackTests/WebRTCVADTest.swift
@@ -85,11 +85,14 @@ class WebRTCVADTest: XCTestCase {
         config.vadMode = .Permissive
         config.frameWidth = 10
         config.sampleRate = 8000
+        config.wakeActiveMin = 1
+        config.wakeActiveMax = 3
         let vad = WebRTCVAD(config, context: context)
         
         /// speech -> no speech
         context.isSpeech = true
-        vad.process(Frame.silence(frameWidth: 10, sampleRate: 8000))
+        vad.process(Frame.silence(frameWidth: config.frameWidth, sampleRate: config.sampleRate))
+        vad.process(Frame.silence(frameWidth: config.frameWidth, sampleRate: config.sampleRate))
         XCTAssertFalse(delegate.failed, "Process should not cause a failure")
         XCTAssertFalse(context.isSpeech, "isSpeech should be false because silence")
         
@@ -106,13 +109,14 @@ class WebRTCVADTest: XCTestCase {
         /// no speech -> speech
         context.isSpeech = false
         vad.process(Frame.voice(frameWidth: 10, sampleRate: 8000))
+        vad.process(Frame.voice(frameWidth: 10, sampleRate: 8000))
         XCTAssertFalse(delegate.failed, "Process should not cause a failure")
         XCTAssert(context.isSpeech, "isSpeech should be true because voice + isSpeech: false")
         
         /// speech
         delegate.reset()
         context.isSpeech = true
-        for _ in 0...9 {
+        for _ in 0...(config.wakeActiveMax-1) {
             vad.process(Frame.voice(frameWidth: 10, sampleRate: 8000))
         }
         XCTAssertFalse(delegate.failed, "Process should not cause a failure")


### PR DESCRIPTION
Moved VAD edge detection from wakeword recognizer to vad because of both encapsulation and because spokestack asr will need it. I did consider the Java algorithm, but I prefer this approach because it consolidates the logic all in one place.

For better wakeword recognition, disabled RMS by default and lowered the default wakeword threshold.