### PR TITLE
Keyword Recognizer

### DIFF
--- a/Spokestack.xcodeproj/project.pbxproj
+++ b/Spokestack.xcodeproj/project.pbxproj
@@ -84,6 +84,12 @@
 		59C2AFE92319CF4100E47AC5 /* SignalProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E0E13422FE2C2B0060F012 /* SignalProcessing.swift */; };
 		59C2AFEA2319CF8A00E47AC5 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FB0C8A22AEE4F100FB9662 /* Data+Extensions.swift */; };
 		59C2AFEE231ED07100E47AC5 /* WebRTCVADTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C2AFED231ED07100E47AC5 /* WebRTCVADTest.swift */; };
+		59C789832582C5640087881D /* TFLiteKeywordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C789822582C5640087881D /* TFLiteKeywordViewController.swift */; };
+		59C789912582CD690087881D /* KeywordDetect.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 59C7898E2582CD690087881D /* KeywordDetect.tflite */; };
+		59C789922582CD690087881D /* KeywordEncode.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 59C7898F2582CD690087881D /* KeywordEncode.tflite */; };
+		59C789932582CD690087881D /* KeywordFilter.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 59C789902582CD690087881D /* KeywordFilter.tflite */; };
+		59D68CA9257EB346001E2587 /* TFLiteKeywordRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D68CA8257EB346001E2587 /* TFLiteKeywordRecognizer.swift */; };
+		59D68CAA257EB346001E2587 /* TFLiteKeywordRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D68CA8257EB346001E2587 /* TFLiteKeywordRecognizer.swift */; };
 		59D78F5F2322D13700728A98 /* AudioControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D78F5E2322D13700728A98 /* AudioControllerTest.swift */; };
 		59D78F612322EAE000728A98 /* SpeechPipelineTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D78F602322EAE000728A98 /* SpeechPipelineTest.swift */; };
 		59E0E13522FE2C2B0060F012 /* SignalProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E0E13422FE2C2B0060F012 /* SignalProcessing.swift */; };
@@ -209,6 +215,11 @@
 		59C1A437252E71F700CE2B69 /* TranscriptEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptEditor.swift; sourceTree = "<group>"; };
 		59C2AFD92319CB7100E47AC5 /* RingBufferTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingBufferTest.swift; sourceTree = "<group>"; };
 		59C2AFED231ED07100E47AC5 /* WebRTCVADTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCVADTest.swift; sourceTree = "<group>"; };
+		59C789822582C5640087881D /* TFLiteKeywordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TFLiteKeywordViewController.swift; sourceTree = "<group>"; };
+		59C7898E2582CD690087881D /* KeywordDetect.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = KeywordDetect.tflite; sourceTree = "<group>"; };
+		59C7898F2582CD690087881D /* KeywordEncode.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = KeywordEncode.tflite; sourceTree = "<group>"; };
+		59C789902582CD690087881D /* KeywordFilter.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = KeywordFilter.tflite; sourceTree = "<group>"; };
+		59D68CA8257EB346001E2587 /* TFLiteKeywordRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TFLiteKeywordRecognizer.swift; sourceTree = "<group>"; };
 		59D78F5E2322D13700728A98 /* AudioControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioControllerTest.swift; sourceTree = "<group>"; };
 		59D78F602322EAE000728A98 /* SpeechPipelineTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechPipelineTest.swift; sourceTree = "<group>"; };
 		59E0E13422FE2C2B0060F012 /* SignalProcessing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalProcessing.swift; sourceTree = "<group>"; };
@@ -276,6 +287,9 @@
 		011C191E216BCA3200DB36FD /* SpokestackFrameworkExample */ = {
 			isa = PBXGroup;
 			children = (
+				59C7898E2582CD690087881D /* KeywordDetect.tflite */,
+				59C7898F2582CD690087881D /* KeywordEncode.tflite */,
+				59C789902582CD690087881D /* KeywordFilter.tflite */,
 				597D0CA723F5B28F00018D71 /* nlu.tflite */,
 				597D0CA423F5B24A00018D71 /* nlu.json */,
 				59E895A023E0B45800C424D3 /* vocab.txt */,
@@ -288,6 +302,7 @@
 				59A0D5BF2204E786003709C3 /* AppleWakewordViewController.swift */,
 				59E8959E23E0AE5C00C424D3 /* NLUViewController.swift */,
 				594FEEEC24C685FA00BB4910 /* SpokestackASRViewController.swift */,
+				59C789822582C5640087881D /* TFLiteKeywordViewController.swift */,
 				59E0E1382301FB920060F012 /* TFLiteViewController.swift */,
 				592C0B7A2385B5E800308CCD /* TTSViewController.swift */,
 				011C1921216BCA3200DB36FD /* ViewController.swift */,
@@ -434,6 +449,7 @@
 				594154B722F8AD2200E3624E /* TFLiteWakewordRecognizer.swift */,
 				59416CCC24B5359F009B9304 /* VADTrigger.swift */,
 				59C15D52234D322A00B091F4 /* WebRTCVAD.swift */,
+				59D68CA8257EB346001E2587 /* TFLiteKeywordRecognizer.swift */,
 			);
 			name = Recognizers;
 			sourceTree = "<group>";
@@ -629,7 +645,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				59E0E13E230DEB7C0060F012 /* Detect.lite in Resources */,
+				59C789932582CD690087881D /* KeywordFilter.tflite in Resources */,
+				59C789922582CD690087881D /* KeywordEncode.tflite in Resources */,
 				59E0E140230DEB7C0060F012 /* Filter.lite in Resources */,
+				59C789912582CD690087881D /* KeywordDetect.tflite in Resources */,
 				597D0CA623F5B24A00018D71 /* nlu.json in Resources */,
 				59E895A123E0B45900C424D3 /* vocab.txt in Resources */,
 				011C192A216BCA3200DB36FD /* LaunchScreen.storyboard in Resources */,
@@ -737,6 +756,7 @@
 				011C1922216BCA3200DB36FD /* ViewController.swift in Sources */,
 				011C1920216BCA3200DB36FD /* AppDelegate.swift in Sources */,
 				59E8959F23E0AE5C00C424D3 /* NLUViewController.swift in Sources */,
+				59C789832582C5640087881D /* TFLiteKeywordViewController.swift in Sources */,
 				594FEEED24C685FA00BB4910 /* SpokestackASRViewController.swift in Sources */,
 				59E0E1392301FB920060F012 /* TFLiteViewController.swift in Sources */,
 				592C0B7B2385B5E800308CCD /* TTSViewController.swift in Sources */,
@@ -776,6 +796,7 @@
 				594154B822F8AD2200E3624E /* TFLiteWakewordRecognizer.swift in Sources */,
 				59FB0C8B22AEE4F100FB9662 /* Data+Extensions.swift in Sources */,
 				01D31F62216BAFA40055FD45 /* AudioController.swift in Sources */,
+				59D68CA9257EB346001E2587 /* TFLiteKeywordRecognizer.swift in Sources */,
 				59C15D53234D322A00B091F4 /* WebRTCVAD.swift in Sources */,
 				597D0CAD23F716AF00018D71 /* NLUService.swift in Sources */,
 				597D0CE12405C2BA00018D71 /* NLUTensorflowSlotParsers.swift in Sources */,
@@ -808,6 +829,7 @@
 				597D0CBA23FB2F5000018D71 /* NLUTensorflow.swift in Sources */,
 				5917AC4F2405C86300CB4900 /* NLUTensorflowSlotParserTest.swift in Sources */,
 				59ECA8C823C939AA003CDB57 /* TextToSpeechResult.swift in Sources */,
+				59D68CAA257EB346001E2587 /* TFLiteKeywordRecognizer.swift in Sources */,
 				597D0CAE23F716AF00018D71 /* NLUService.swift in Sources */,
 				59AA893D2472EE5500197D7A /* NLUTensorflowTest.swift in Sources */,
 				59A8DBF92384ABF000F97700 /* TextToSpeechTest.swift in Sources */,

--- a/Spokestack.xcodeproj/project.pbxproj
+++ b/Spokestack.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		59C789912582CD690087881D /* KeywordDetect.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 59C7898E2582CD690087881D /* KeywordDetect.tflite */; };
 		59C789922582CD690087881D /* KeywordEncode.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 59C7898F2582CD690087881D /* KeywordEncode.tflite */; };
 		59C789932582CD690087881D /* KeywordFilter.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 59C789902582CD690087881D /* KeywordFilter.tflite */; };
+		59C789972587C3180087881D /* TFLiteKeywordRecognizerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C789962587C3180087881D /* TFLiteKeywordRecognizerTest.swift */; };
 		59D68CA9257EB346001E2587 /* TFLiteKeywordRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D68CA8257EB346001E2587 /* TFLiteKeywordRecognizer.swift */; };
 		59D68CAA257EB346001E2587 /* TFLiteKeywordRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D68CA8257EB346001E2587 /* TFLiteKeywordRecognizer.swift */; };
 		59D78F5F2322D13700728A98 /* AudioControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D78F5E2322D13700728A98 /* AudioControllerTest.swift */; };
@@ -111,6 +112,9 @@
 		59EF51BF233013A9006BA0BD /* AppleSpeechRecognizerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EF51BE233013A9006BA0BD /* AppleSpeechRecognizerTest.swift */; };
 		59EF51C123328D57006BA0BD /* AppleWakewordRecognizerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EF51C023328D57006BA0BD /* AppleWakewordRecognizerTest.swift */; };
 		59EF51C32332E57B006BA0BD /* Frame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EF51C22332E57B006BA0BD /* Frame.swift */; };
+		59F492CA2588364700F98986 /* mock_kw_detect.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 59F492C72588364700F98986 /* mock_kw_detect.tflite */; };
+		59F492CB2588364700F98986 /* mock_kw_filter.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 59F492C82588364700F98986 /* mock_kw_filter.tflite */; };
+		59F492CC2588364700F98986 /* mock_kw_encode.tflite in Resources */ = {isa = PBXBuildFile; fileRef = 59F492C92588364700F98986 /* mock_kw_encode.tflite */; };
 		59FB0C8B22AEE4F100FB9662 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FB0C8A22AEE4F100FB9662 /* Data+Extensions.swift */; };
 		59FB0C8D22B0640700FB9662 /* RingBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FB0C8C22B0640700FB9662 /* RingBuffer.swift */; };
 		59FB0C8F22B0682900FB9662 /* FFT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FB0C8E22B0682900FB9662 /* FFT.swift */; };
@@ -219,6 +223,7 @@
 		59C7898E2582CD690087881D /* KeywordDetect.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = KeywordDetect.tflite; sourceTree = "<group>"; };
 		59C7898F2582CD690087881D /* KeywordEncode.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = KeywordEncode.tflite; sourceTree = "<group>"; };
 		59C789902582CD690087881D /* KeywordFilter.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = KeywordFilter.tflite; sourceTree = "<group>"; };
+		59C789962587C3180087881D /* TFLiteKeywordRecognizerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TFLiteKeywordRecognizerTest.swift; sourceTree = "<group>"; };
 		59D68CA8257EB346001E2587 /* TFLiteKeywordRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TFLiteKeywordRecognizer.swift; sourceTree = "<group>"; };
 		59D78F5E2322D13700728A98 /* AudioControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioControllerTest.swift; sourceTree = "<group>"; };
 		59D78F602322EAE000728A98 /* SpeechPipelineTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechPipelineTest.swift; sourceTree = "<group>"; };
@@ -238,6 +243,9 @@
 		59EF51BE233013A9006BA0BD /* AppleSpeechRecognizerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSpeechRecognizerTest.swift; sourceTree = "<group>"; };
 		59EF51C023328D57006BA0BD /* AppleWakewordRecognizerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleWakewordRecognizerTest.swift; sourceTree = "<group>"; };
 		59EF51C22332E57B006BA0BD /* Frame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Frame.swift; sourceTree = "<group>"; };
+		59F492C72588364700F98986 /* mock_kw_detect.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = mock_kw_detect.tflite; sourceTree = "<group>"; };
+		59F492C82588364700F98986 /* mock_kw_filter.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = mock_kw_filter.tflite; sourceTree = "<group>"; };
+		59F492C92588364700F98986 /* mock_kw_encode.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = mock_kw_encode.tflite; sourceTree = "<group>"; };
 		59FB0C8A22AEE4F100FB9662 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
 		59FB0C8C22B0640700FB9662 /* RingBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingBuffer.swift; sourceTree = "<group>"; };
 		59FB0C8E22B0682900FB9662 /* FFT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFT.swift; sourceTree = "<group>"; };
@@ -356,6 +364,9 @@
 		01D31F48216BAF260055FD45 /* SpokestackTests */ = {
 			isa = PBXGroup;
 			children = (
+				59F492C72588364700F98986 /* mock_kw_detect.tflite */,
+				59F492C92588364700F98986 /* mock_kw_encode.tflite */,
+				59F492C82588364700F98986 /* mock_kw_filter.tflite */,
 				59D78F5E2322D13700728A98 /* AudioControllerTest.swift */,
 				59EF51BE233013A9006BA0BD /* AppleSpeechRecognizerTest.swift */,
 				59EF51C023328D57006BA0BD /* AppleWakewordRecognizerTest.swift */,
@@ -371,6 +382,7 @@
 				59E3E71424C1088200F12CC4 /* SpokestackSpeechRecognizerTest.swift */,
 				59A8DBF82384ABF000F97700 /* TextToSpeechTest.swift */,
 				59AB0B0624786B69007B7582 /* TFLiteWakewordRecognizerTest.swift */,
+				59C789962587C3180087881D /* TFLiteKeywordRecognizerTest.swift */,
 				59C2AFED231ED07100E47AC5 /* WebRTCVADTest.swift */,
 				01D31F4B216BAF260055FD45 /* Info.plist */,
 				59FE4A9624805F5F00976825 /* mock_detector.tflite */,
@@ -446,10 +458,10 @@
 				5967108D21F7AE6B00CBFC88 /* AppleSpeechRecognizer.swift */,
 				59365947220889EE00C0365F /* AppleWakewordRecognizer.swift */,
 				59E3E71124C0E83000F12CC4 /* SpokestackSpeechRecognizer.swift */,
+				59D68CA8257EB346001E2587 /* TFLiteKeywordRecognizer.swift */,
 				594154B722F8AD2200E3624E /* TFLiteWakewordRecognizer.swift */,
 				59416CCC24B5359F009B9304 /* VADTrigger.swift */,
 				59C15D52234D322A00B091F4 /* WebRTCVAD.swift */,
-				59D68CA8257EB346001E2587 /* TFLiteKeywordRecognizer.swift */,
 			);
 			name = Recognizers;
 			sourceTree = "<group>";
@@ -671,9 +683,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				59FE4A912480580900976825 /* mock_encoder.tflite in Resources */,
+				59F492CA2588364700F98986 /* mock_kw_detect.tflite in Resources */,
 				59FE4A9724805F5F00976825 /* mock_detector.tflite in Resources */,
 				59FE4A902480580900976825 /* mock_nlu.tflite in Resources */,
 				59FE4A9324805EA300976825 /* mock_filter.tflite in Resources */,
+				59F492CB2588364700F98986 /* mock_kw_filter.tflite in Resources */,
+				59F492CC2588364700F98986 /* mock_kw_encode.tflite in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -817,6 +832,7 @@
 				59C2AFE22319CEAE00E47AC5 /* TFLiteWakewordRecognizer.swift in Sources */,
 				59E895A423E0F44900C424D3 /* Array+Extensions.swift in Sources */,
 				59E3E71524C1088200F12CC4 /* SpokestackSpeechRecognizerTest.swift in Sources */,
+				59C789972587C3180087881D /* TFLiteKeywordRecognizerTest.swift in Sources */,
 				59C2AFE62319CEEF00E47AC5 /* RingBuffer.swift in Sources */,
 				01D31F70216BAFD90055FD45 /* SpeechContext.swift in Sources */,
 				59A8DBFA2384AC0100F97700 /* TextToSpeech.swift in Sources */,

--- a/Spokestack/Error.swift
+++ b/Spokestack/Error.swift
@@ -68,7 +68,8 @@ public enum VADError: Error, Equatable, LocalizedError {
     }
 }
 
-/// Errors thrown by implementors of the WakewordRecognizer protocol.
+/// Errors thrown by  command models.
+/// - SeeAlso: `TFLiteWakewordRecognizer`, `TFLiteKeywordRecognizer`
 public enum CommandModelError: Error, Equatable, LocalizedError {
     /// The command recognizer was unable to configure the recognizer model(s).
     case model(String)

--- a/Spokestack/Error.swift
+++ b/Spokestack/Error.swift
@@ -69,16 +69,16 @@ public enum VADError: Error, Equatable, LocalizedError {
 }
 
 /// Errors thrown by implementors of the WakewordRecognizer protocol.
-public enum WakewordModelError: Error, Equatable, LocalizedError {
-    /// The WakewordRecognizer was unable to configure the recognizer model(s).
+public enum CommandModelError: Error, Equatable, LocalizedError {
+    /// The command recognizer was unable to configure the recognizer model(s).
     case model(String)
-    /// The WakewordRecognizer encountered an error during the processing of the audio frame.
+    /// The rcommand ecognizer encountered an error during the processing of the audio frame.
     case process(String)
-    /// The WakewordRecognizer encountered an error during the configuration or running of the filter model.
+    /// The command recognizer encountered an error during the configuration or running of the filter model.
     case filter(String)
-    /// The WakewordRecognizer encountered an error during the configuration or running of the encode model.
+    /// The command recognizer encountered an error during the configuration or running of the encode model.
     case encode(String)
-    /// The WakewordRecognizer encountered an error during the configuration or running of the detect model.
+    /// The command recognizer encountered an error during the configuration or running of the detect model.
     case detect(String)
     
     /// `LocalizedError` implementation so that `localizedDescription` isn't an enum index.

--- a/Spokestack/Error.swift
+++ b/Spokestack/Error.swift
@@ -73,7 +73,7 @@ public enum VADError: Error, Equatable, LocalizedError {
 public enum CommandModelError: Error, Equatable, LocalizedError {
     /// The command recognizer was unable to configure the recognizer model(s).
     case model(String)
-    /// The rcommand ecognizer encountered an error during the processing of the audio frame.
+    /// The command recognizer encountered an error during the processing of the audio frame.
     case process(String)
     /// The command recognizer encountered an error during the configuration or running of the filter model.
     case filter(String)

--- a/Spokestack/RingBuffer.swift
+++ b/Spokestack/RingBuffer.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// A simple circular buffer of values.
 final class RingBuffer <T> {
-
+    
     // MARK: Public (properties)
     
     /// The number of empty spaces remaining in the RingBuffer until it's full.
@@ -81,11 +81,10 @@ final class RingBuffer <T> {
     func read() throws -> T {
         if self.isEmpty {
             throw RingBufferStateError.illegalState(message: "ring buffer is empty")
-        } else {
-            let value: T = self.data[self.rpos]
-            self.rpos = self.pos(self.rpos + 1)
-            return value
         }
+        let value: T = self.data[self.rpos]
+        self.rpos = self.pos(self.rpos + 1)
+        return value
     }
     
     /// Writes the next value to the buffer.

--- a/Spokestack/RingBuffer.swift
+++ b/Spokestack/RingBuffer.swift
@@ -81,10 +81,11 @@ final class RingBuffer <T> {
     func read() throws -> T {
         if self.isEmpty {
             throw RingBufferStateError.illegalState(message: "ring buffer is empty")
+        } else {
+            let value: T = self.data[self.rpos]
+            self.rpos = self.pos(self.rpos + 1)
+            return value
         }
-        let value: T = self.data[self.rpos]
-        self.rpos = self.pos(self.rpos + 1)
-        return value
     }
     
     /// Writes the next value to the buffer.

--- a/Spokestack/SpeechConfiguration.swift
+++ b/Spokestack/SpeechConfiguration.swift
@@ -21,9 +21,11 @@ import Foundation
     public var fftWindowType: SignalProcessing.FFTWindowType = .hann
     /// The desired linear Root Mean Squared (RMS) signal energy, which is used for signal normalization and should be tuned to the RMS target used during wakeword model training.
     /// - SeeAlso: `TFLiteWakewordRecognizer`
+    @available(*, deprecated, message: "RMS normalization is no longer used during wakeword recognition.")
     @objc public var rmsTarget: Float = 0.08
     /// The Exponentially Weighted Moving Average (EWMA) update rate for the current  Root Mean Squared (RMS) signal energy (0 for no RMS normalization).
     /// - SeeAlso: `TFLiteWakewordRecognizer`
+    @available(*, deprecated, message: "RMS normalization is no longer used during wakeword recognition.")
     @objc public var rmsAlpha: Float = 0.0
     /// The size of the signal window used to calculate the STFT, in number of samples - should be a power of 2 for maximum efficiency.
     /// - SeeAlso: `TFLiteWakewordRecognizer`
@@ -159,17 +161,11 @@ import Foundation
     /// - Remark: ex: "yes,no"
     /// - Warning: cannot contain spaces
     /// - SeeAlso: `TFLiteKeywordRecognizer`
-    @objc public var keywords: String = "bed,bird,cat,dog,down,eight,five,four,go,happy,house,left,marvin,nine,no,off,on,one,right,seven,sheila,six,stop,three,tree,two,up,wow,yes,zero"
+    @objc public var keywords: String = ""
     /// The name of the window function to apply to each audio frame before calculating the STFT.
     /// - Remark: Currently the "hann" window is supported.
     /// - SeeAlso: `TFLiteWakewordRecognizer`
     public var keywordFFTWindowType: SignalProcessing.FFTWindowType = .hann
-    /// The desired linear Root Mean Squared (RMS) signal energy, which is used for signal normalization and should be tuned to the RMS target used during wakeword model training.
-    /// - SeeAlso: `TFLiteWakewordRecognizer`
-    @objc public var keywordRMSTarget: Float = 0.08
-    /// The Exponentially Weighted Moving Average (EWMA) update rate for the current  Root Mean Squared (RMS) signal energy (0 for no RMS normalization).
-    /// - SeeAlso: `TFLiteWakewordRecognizer`
-    @objc public var keywordRMSAlpha: Float = 0.0
     /// The size of the signal window used to calculate the STFT, in number of samples - should be a power of 2 for maximum efficiency.
     /// - SeeAlso: `TFLiteWakewordRecognizer`
     @objc public var keywordFFTWindowSize: Int = 512
@@ -188,5 +184,4 @@ import Foundation
     /// The length of the sliding window of encoder output used as an input to the wakeword recognizer classifier, in milliseconds.
     /// - SeeAlso: `TFLiteWakewordRecognizer`
     @objc public var keywordEncodeLength: Int = 920
-    /// The threshold of the wakeword recognizer classifier's posterior output, above which the wakeword recognizer activates the pipeline, in the range [0, 1].
 }

--- a/Spokestack/SpeechConfiguration.swift
+++ b/Spokestack/SpeechConfiguration.swift
@@ -131,4 +131,62 @@ import Foundation
     /// - Note: Requires  `NLUTensorflow` to be correctly configured, notably with `nluModelPath`, `nluModelMetadataPath`, and `nluVocabularyPath`.
     /// - SeeAlso: `Spokestack`, `NLUTensorflow`, `nluModelPath`, `nluModelMetadataPath`, and `nluVocabularyPath`
     @objc public var automaticallyClassifyTranscript = true
+    /// The filename of the machine learning model used for the filtering step of the keyword recognizer.
+    /// - Remarks: Both the file name and the file path are configurable to allow for flexibility in constructing the path that the recognizer will attempt to load the model from.
+    /// - SeeAlso: `TFLiteKeywordRecognizer`
+    @objc public var keywordFilterModelName: String = "KeywordFilter"
+    /// The filename of the machine learning model used for the encoding step of the keyword recognizer.
+    /// - Remarks: Both the file name and the file path are configurable to allow for flexibility in constructing the path that the recognizer will attempt to load the model from.
+    /// - SeeAlso: `TFLiteKeywordRecognizer`
+    @objc public var keywordEncodeModelName: String = "KeywordEncode"
+    /// The filename of the machine learning model used for the detect step of the keyword recognizer.
+    /// - Remarks: Both the file name and the file path are configurable to allow for flexibility in constructing the path that the recognizer will attempt to load the model from.
+    /// - SeeAlso: `TFLiteKeywordRecognizer`
+    @objc public var keywordDetectModelName: String = "KeywordDetect"
+    /// The filesystem path to the machine learning model for the filtering step of the keyword recognizer.
+    /// - SeeAlso: `TFLiteKeywordRecognizer`
+    @objc public var keywordFilterModelPath: String = "KeywordFilter.tflite"
+    /// The filesystem path to the machine learning model for the encoding step of the keyword recognizer.
+    /// - SeeAlso: `TFLiteKeywordRecognizer`
+    @objc public var keywordEncodeModelPath: String = "KeywordEncode.tflite"
+    /// The filesystem path to the machine learning model for the detect step of the keyword recognizer.
+    /// - SeeAlso: `TFLiteKeywordRecognizer`
+    @objc public var keywordDetectModelPath: String = "KeywordDetect.tflite"
+    /// The threshold of the keyword recognizer's posterior output, above which the keyword recognizer emits a recognition event for the most probable keyword.
+    /// - SeeAlso: `TFLiteKeywordRecognizer`
+    @objc public var keywordThreshold: Float = 0.5
+    /// A comma-separated list of keywords to recognize.
+    /// - Remark: ex: "yes,no"
+    /// - Warning: cannot contain spaces
+    /// - SeeAlso: `TFLiteKeywordRecognizer`
+    @objc public var keywords: String = "bed,bird,cat,dog,down,eight,five,four,go,happy,house,left,marvin,nine,no,off,on,one,right,seven,sheila,six,stop,three,tree,two,up,wow,yes,zero"
+    /// The name of the window function to apply to each audio frame before calculating the STFT.
+    /// - Remark: Currently the "hann" window is supported.
+    /// - SeeAlso: `TFLiteWakewordRecognizer`
+    public var keywordFFTWindowType: SignalProcessing.FFTWindowType = .hann
+    /// The desired linear Root Mean Squared (RMS) signal energy, which is used for signal normalization and should be tuned to the RMS target used during wakeword model training.
+    /// - SeeAlso: `TFLiteWakewordRecognizer`
+    @objc public var keywordRMSTarget: Float = 0.08
+    /// The Exponentially Weighted Moving Average (EWMA) update rate for the current  Root Mean Squared (RMS) signal energy (0 for no RMS normalization).
+    /// - SeeAlso: `TFLiteWakewordRecognizer`
+    @objc public var keywordRMSAlpha: Float = 0.0
+    /// The size of the signal window used to calculate the STFT, in number of samples - should be a power of 2 for maximum efficiency.
+    /// - SeeAlso: `TFLiteWakewordRecognizer`
+    @objc public var keywordFFTWindowSize: Int = 512
+    /// The length of time to skip each time the overlapping STFT is calculated, in milliseconds.
+    /// - SeeAlso: `TFLiteWakewordRecognizer`
+    @objc public var keywordFFTHopLength: Int = 10
+    /// The length of a frame in the mel spectrogram used as an input to the wakeword recognizer encoder, in milliseconds.
+    /// - SeeAlso: `TFLiteWakewordRecognizer`
+    @objc public var keywordMelFrameLength: Int = 1090
+    /// The number of filterbank components in each mel spectrogram frame sent to the wakeword recognizer.
+    /// - SeeAlso: `TFLiteWakewordRecognizer`
+    @objc public var keywordMelFrameWidth: Int = 40
+    /// The size of the wakeword recognizer's encoder window output.
+    /// - SeeAlso: `TFLiteWakewordRecognizer`
+    @objc public var keywordEncodeWidth: Int = 128
+    /// The length of the sliding window of encoder output used as an input to the wakeword recognizer classifier, in milliseconds.
+    /// - SeeAlso: `TFLiteWakewordRecognizer`
+    @objc public var keywordEncodeLength: Int = 920
+    /// The threshold of the wakeword recognizer classifier's posterior output, above which the wakeword recognizer activates the pipeline, in the range [0, 1].
 }

--- a/Spokestack/SpeechPipeline.swift
+++ b/Spokestack/SpeechPipeline.swift
@@ -80,7 +80,9 @@ import Dispatch
             case .vadTrigger:
                 return VADTrigger(configuration, context: self.context)
             case .spokestackSpeech:
-                return SpokestackSpeechRecognizer(configuration, context: context)
+                return SpokestackSpeechRecognizer(configuration, context: self.context)
+            case .tfLiteKeywordRecognizer:
+                return TFLiteKeywordRecognizer(configuration, context: self.context)
             }
         }
         

--- a/Spokestack/SpeechProcessor.swift
+++ b/Spokestack/SpeechProcessor.swift
@@ -45,6 +45,8 @@ internal enum SpeechProcessors: Int {
     case vadTrigger
     /// spokestackSpeech
     case spokestackSpeech
+    /// tfLiteKeywordRecognizer
+    case tfLiteKeywordRecognizer
 }
 
 /// Profiles that may be passed to `SpeechPipelineBuilder` for easy pipeline configuring.
@@ -63,6 +65,12 @@ internal enum SpeechProcessors: Int {
     case tfLiteWakewordSpokestackSpeech
     /// Spokestack ASR that is manually activated and deactivated
     case pushToTalkSpokestackSpeech
+    /// VAD-sensitive Apple wakeword activates TFLite Keyword Recognizer
+    case appleWakewordKeyword
+    /// VAD-sensitive TFLiteWakeword activates TFLite Keyword Recognizer
+    case tfLiteWakewordKeyword
+    /// VAD-triggered TFLite Keyword Recognizer
+    case vadTriggerKeyword
 }
 
 extension SpeechPipelineProfiles {
@@ -84,6 +92,12 @@ extension SpeechPipelineProfiles {
             return [.vad, .tfLiteWakeword, .spokestackSpeech]
         case .appleWakewordAppleSpeech:
             return [.vad, .appleWakeword, .appleSpeech]
+        case .appleWakewordKeyword:
+            return [.vad, .appleWakeword, .tfLiteKeywordRecognizer]
+        case .tfLiteWakewordKeyword:
+            return [.vad, .tfLiteWakeword, .tfLiteKeywordRecognizer]
+        case .vadTriggerKeyword:
+            return [.vad, .vadTrigger, .tfLiteKeywordRecognizer]
         }
     }
 }

--- a/Spokestack/TFLiteKeywordRecognizer.swift
+++ b/Spokestack/TFLiteKeywordRecognizer.swift
@@ -1,0 +1,373 @@
+//
+//  TFLiteKeywordRecognizer.swift
+//  Spokestack
+//
+//  Created by Noel Weichbrodt on 12/7/20.
+//  Copyright © 2020 Spokestack, Inc. All rights reserved.
+//
+
+import Foundation
+import TensorFlowLite
+
+@objc public class TFLiteKeywordRecognizer: NSObject {
+    
+    /// Configuration for the recognizer.
+    @objc public var configuration: SpeechConfiguration
+    
+    /// Global state for the speech pipeline.
+    @objc public var context: SpeechContext
+    
+    private var isActive: Bool = false
+    private var activation = 0
+
+    private var rmsValue: Float = 0.0
+    private var prevSample: Float = 0.0
+    private var sampleWindow: RingBuffer<Float>!
+    private var fftFrame: Array<Float> = []
+    private var fftWindow: Array<Float> = []
+    private var fft: FFT!
+    private var hopLength: Int = 0
+    private var frameWindow: RingBuffer<Float>!
+    private var encodeState: RingBuffer<Float>!
+    private var encodeWindow: RingBuffer<Float>!
+    private var classes: [String] = []
+    
+    // TensorFlowLite models
+    private var filterModel: Interpreter?
+    private var encodeModel: Interpreter?
+    private var detectModel: Interpreter?
+    internal enum Tensors: Int, CaseIterable {
+        case encode
+        case state
+    }
+    
+    
+    private var sampleCollector: Array<Float>?
+    private var fftFrameCollector: String?
+    private var filterCollector: Array<Float>?
+    private var encodeCollector: Array<Float>?
+    
+    
+    /// Initializes a TFLiteKeywordRecognizer instance.
+    ///
+    /// A recognizer is initialized by, and receives `startStreaming` and `stopStreaming` events from, an instance of `SpeechPipeline`.
+    ///
+    /// The TFLiteKeywordRecognizer receives audio data frames to `process` from `AudioController`.
+    /// - Parameters:
+    ///   - configuration: Configuration for the recognizer.
+    ///   - context: Global state for the speech pipeline.
+    @objc public init(_ configuration: SpeechConfiguration, context: SpeechContext) {
+        self.configuration = configuration
+        self.context = context
+        super.init()
+        self.initialize(configuration)
+    }
+    
+    private func initialize(_ c: SpeechConfiguration) {
+        self.rmsValue = c.keywordRMSTarget
+        self.sampleWindow = RingBuffer(c.keywordFFTWindowSize, repeating: 0.0)
+        self.fftFrame = Array(repeating: 0.0, count: c.keywordFFTWindowSize)
+        self.fftWindow = SignalProcessing.fftWindowDispatch(windowType: c.keywordFFTWindowType, windowLength: c.keywordFFTWindowSize)
+        self.fft = FFT(c.keywordFFTWindowSize)
+        self.hopLength = c.keywordFFTHopLength * c.sampleRate / 1000
+        let melLength: Int = c.keywordMelFrameLength * c.sampleRate / 1000 / self.hopLength
+        self.frameWindow = RingBuffer(melLength * c.keywordMelFrameWidth, repeating: 0.0)
+        self.encodeState = RingBuffer(c.keywordEncodeWidth, repeating: 0.0)
+        self.encodeState.fill(0.0) // fill now because the encoded state is used to feed-forward
+        let encodeLength = c.keywordEncodeLength * c.sampleRate / 1000 / self.hopLength
+        self.encodeWindow = RingBuffer(encodeLength * c.keywordEncodeWidth, repeating: -1.0)
+        self.classes = self.configuration.keywords.components(separatedBy: ",")
+        
+        // Tracing
+        if c.tracing.rawValue <= Trace.Level.DEBUG.rawValue {
+            self.sampleCollector = []
+            self.fftFrameCollector = ""
+            self.filterCollector = []
+            self.encodeCollector = []
+        }
+        
+        // tensorflow model initialization
+        do {
+            self.filterModel = try Interpreter(modelPath: c.keywordFilterModelPath)
+            if let model = self.filterModel {
+                try model.allocateTensors()
+            } else {
+                throw CommandModelError.filter("\(c.keywordFilterModelPath) could not be initialized")
+            }
+            
+            self.encodeModel = try Interpreter(modelPath: c.keywordEncodeModelPath)
+            if let model = self.encodeModel {
+                try model.allocateTensors()
+                if (model.inputTensorCount != Tensors.allCases.count) {
+                    throw CommandModelError.encode("Keyword encode model input dimension is \(model.inputTensorCount) which does not matched expected dimension \(Tensors.allCases.count)")
+                }
+            } else {
+                throw CommandModelError.encode("\(c.keywordEncodeModelPath) could not be initialized")
+            }
+            
+            self.detectModel = try Interpreter(modelPath: c.keywordDetectModelPath)
+            if let model = self.detectModel {
+                try model.allocateTensors()
+            } else {
+                throw CommandModelError.detect("\(c.keywordDetectModelPath) could not be initialized")
+            }
+        } catch let message {
+            self.context.dispatch { $0.failure(error: CommandModelError.model("TFLiteKeywordRecognizer configureAttentionModels \(message)")) }
+        }
+    }
+    
+    private func sample(_ frame: Data) throws {
+        // Preallocate an array of data elements in the frame for use in RMS and sampling
+        let elements: Array<Int16> = frame.elements()
+        
+        // Update the rms normalization factors
+        // Maintain an ewma of the rms signal energy for speech samples
+        if self.configuration.keywordRMSAlpha > 0 {
+            self.rmsValue = self.configuration.keywordRMSAlpha * SignalProcessing.rms(frame, elements) + (1 - self.configuration.keywordRMSAlpha) * self.rmsValue
+        }
+        
+        // Process all samples in the frame
+        for e in elements {
+            // Normalize and clip the 16-bit sample to the target rms energy
+            var sample: Float = Float(e) / Float(Int16.max)
+            sample = sample * (self.configuration.keywordRMSTarget / self.rmsValue)
+            sample = max(-1.0, min(sample, 1.0))
+            
+            // Run a pre-emphasis filter to balance high frequencies and eliminate any dc energy
+            let currentSample: Float = sample
+            sample -= self.configuration.preEmphasis * self.prevSample
+            self.prevSample = currentSample
+            
+            if self.configuration.tracing.rawValue <= Trace.Level.DEBUG.rawValue {
+                self.sampleCollector?.append(sample)
+            }
+            
+            // Process the sample
+            // - write it to the sample sliding window
+            // - run the remainder of the detection pipleline if speech
+            // - advance the sample sliding window
+            try self.sampleWindow.write(sample)
+            if self.sampleWindow.isFull {
+                try self.analyze()
+            }
+        }
+    }
+    
+    private func analyze() throws {
+        // The current sample window contains speech, so apply the fft windowing function to it
+        for (index, _) in self.fftFrame.enumerated() {
+            let sample: Float = try self.sampleWindow.read()
+            self.fftFrame[index] = sample * self.fftWindow[index]
+        }
+        
+        // Compute the stft spectrogram
+        self.fft.forward(&self.fftFrame)
+        
+        // rewind the sample window for another run
+        self.sampleWindow.rewind().seek(self.hopLength)
+        
+        if self.configuration.tracing.rawValue <= Trace.Level.DEBUG.rawValue {
+            self.fftFrameCollector? += "\(self.fftFrame)\n"
+        }
+        
+        // filter() will utilize the stft spectrogram as input for the filter model
+        try self.filter()
+    }
+    
+    private func filter() throws -> Void {
+        // utilize the stft spectrogram as input for the filter model
+        do {
+            guard let model = self.filterModel else {
+                throw CommandModelError.filter("model was not initialized")
+            }
+            // inputs
+            // compute the magnitude of the spectrogram
+            let magnitude = (self.fftFrame.count / 2) + 1
+            // copy the spectrogram into the filter model's input
+            _ = try self
+                .fftFrame
+                .prefix(magnitude)
+                .withUnsafeBytes(
+                    {try model.copy(Data($0), toInputAt: 0)})
+            
+            // calculate
+            try model.invoke()
+            
+            // outputs
+            let output = try model.output(at: 0)
+            let results = output.data.toArray(type: Float32.self, count: output.data.count / 4)
+            self.frameWindow.rewind().seek(self.configuration.keywordMelFrameWidth)
+            for r in results {
+                try self.frameWindow.write(r)
+                if self.configuration.tracing.rawValue <= Trace.Level.DEBUG.rawValue {
+                    self.filterCollector?.append(r)
+                }
+            }
+        } catch let message {
+            throw CommandModelError.filter("TFLiteKeywordRecognizer filter \(message)")
+        }
+        
+        // send frameWindow to encoding model
+        try self.encode()
+    }
+    
+    private func encode() throws -> Void {
+        do {
+            guard let model = self.encodeModel else {
+                throw CommandModelError.encode("model was not initialized")
+            }
+            // inputs: frameWindow and encodeState
+            self.frameWindow.rewind()
+            // TODO: model.copy requires that the data be sized to exactly the same as the tensor, so we can't just do read()s off the ringbuffer and copy over piecewise. This introduces an aggrevating overhead of having to copy the ringbuffer into an array before copying over to the tensor. Maybe use a fixed-sized array that is advanced based off the fft frame size?
+            var frameWindowArray: Array<Float32> = []
+            while !self.frameWindow.isEmpty {
+                let f = try self.frameWindow.read()
+                frameWindowArray.append(f)
+            }
+            var stateArray: Array<Float32> = []
+            for _ in 0..<self.configuration.keywordEncodeWidth {
+                let f = try self.encodeState.read()
+                stateArray.append(f)
+            }
+            _ = try frameWindowArray
+                .withUnsafeBytes(
+                    {try model.copy(Data($0), toInputAt: Tensors.encode.rawValue)})
+            _ = try stateArray
+                .withUnsafeBytes(
+                    {try model.copy(Data($0), toInputAt: Tensors.state.rawValue)})
+            
+            // calculate
+            try model.invoke()
+            
+            // outputs
+            let encodeOutput = try model.output(at: Tensors.encode.rawValue)
+            let encodeResults = encodeOutput.data.toArray(type: Float32.self, count: encodeOutput.data.count / 4)
+            self.encodeWindow.rewind().seek(self.configuration.keywordEncodeWidth)
+            for r in encodeResults {
+                try self.encodeWindow.write(r)
+                if self.configuration.tracing.rawValue <= Trace.Level.DEBUG.rawValue {
+                    self.encodeCollector?.append(r)
+                }
+            }
+            let stateOutput = try model.output(at: Tensors.state.rawValue)
+            let stateResults = stateOutput.data.toArray(type: Float32.self, count: stateOutput.data.count / 4)
+            for r in stateResults {
+                try self.encodeState.write(r)
+            }
+        } catch let message {
+            throw CommandModelError.encode("TFLiteKeywordRecognizer encode \(message)")
+        }
+    }
+    
+    private func detect() throws {
+        if self.encodeWindow.isFull {
+            do {
+                guard let model = self.detectModel else {
+                    throw CommandModelError.encode("model was not initialized")
+                }
+                // inputs: encodeWindow
+                var encodeWindowArray: Array<Float32> = []
+                self.encodeWindow.rewind()
+                while !self.encodeWindow.isEmpty {
+                    let f = try self.encodeWindow.read()
+                    encodeWindowArray.append(f)
+                }
+                _ = try encodeWindowArray
+                    .withUnsafeBytes(
+                        {try model.copy(Data($0), toInputAt: 0)})
+                
+                // calculate
+                try model.invoke()
+                
+                // outputs
+                let detectOutput = try model.output(at: 0)
+                let detectResults = detectOutput.data.toArray(type: Float32.self, count: detectOutput.data.count / 4)
+                
+                // if the argmax of the distribution of class posteriors exceeeds the threshold, emit a recognition of that class, otherwise timeout.
+                let classArgmax = detectResults.argmax()
+                
+                Trace.trace(.INFO, message: "detected \(self.classes[classArgmax.0]) \(classArgmax)", config: self.configuration, context: self.context, caller: self)
+                
+                if classArgmax.1 > self.configuration.keywordThreshold {
+                    self.context.confidence = classArgmax.1
+                    self.context.transcript = self.classes[classArgmax.0]
+                    self.context.dispatch { $0.didRecognize?(self.context) }
+                } else {
+                    self.context.dispatch { $0.didTimeout?() }
+                }
+                self.reset()
+            } catch let message {
+                throw CommandModelError.detect("TFLiteKeywordRecognizer detect \(message)")
+            }
+        }
+    }
+    
+    private func reset() -> Void {
+        // Empty the sample buffer, so that only contiguous speech samples are written to it
+        self.sampleWindow.reset()
+        
+        // Reset and fill the other buffers, which prevents them from lagging the detection
+        self.frameWindow.reset().fill(0)
+        self.encodeWindow.reset().fill(-1.0)
+        self.encodeState.reset().fill(0)
+    }
+}
+
+extension TFLiteKeywordRecognizer : SpeechProcessor {
+    
+    public func startStreaming() {}
+    
+    public func stopStreaming() {
+        self.isActive = false
+    }
+    
+    public func process(_ frame: Data) {
+        audioProcessingQueue.async {[weak self] in
+            guard let strongSelf = self else { return }
+            if strongSelf.context.isActive {
+                do {
+                    try strongSelf.sample(frame)
+                } catch let error {
+                    strongSelf.context.dispatch { $0.failure(error: error) }
+                }
+                // sample every frame while active
+                if !strongSelf.isActive {
+                    strongSelf.isActive = true
+                } else if
+                    (strongSelf.isActive
+                        && strongSelf.activation <= strongSelf.configuration.wakeActiveMax)
+                        ||
+                        strongSelf.activation <= strongSelf.configuration.wakeActiveMin {
+                    // already sampled, but in the midst of activation, so don't deactiavte yet
+                    strongSelf.activation += strongSelf.configuration.frameWidth
+                } else {
+                    strongSelf.run()
+                    strongSelf.deactivate()
+                }
+            } else if strongSelf.isActive {
+                do {
+                    try strongSelf.sample(frame)
+                } catch let error {
+                    strongSelf.context.dispatch { $0.failure(error: error) }
+                }
+                strongSelf.run()
+                strongSelf.deactivate()
+            }
+        }
+    }
+    
+    private func deactivate() {
+        self.context.isActive = false
+        self.isActive = false
+        self.activation = 0
+        self.context.dispatch { $0.didDeactivate?() }
+    }
+    
+    private func run() {
+        do {
+            try self.detect()
+        } catch let error {
+            self.context.dispatch { $0.failure(error: error) }
+        }
+    }
+}

--- a/Spokestack/TFLiteWakewordRecognizer.swift
+++ b/Spokestack/TFLiteWakewordRecognizer.swift
@@ -71,7 +71,6 @@ import TensorFlowLite
     private var stateWidth: Int = 0
     private var encodeWindow: RingBuffer<Float>!
     private var encodeState: RingBuffer<Float>!
-    private var detectWindow: RingBuffer<Float>!
     
     // attention model posteriors
     private var posteriorThreshold: Float = 0
@@ -83,7 +82,6 @@ import TensorFlowLite
     private var filterCollector: Array<Float>?
     private var encodeCollector: Array<Float>?
     private var stateCollector: Array<Float>?
-    private var detectCollector: Array<Float>?
     private var posteriorMax: Float?
     
     // MARK: NSObject methods
@@ -127,25 +125,27 @@ import TensorFlowLite
             if let model = self.filterModel {
                 try model.allocateTensors()
             } else {
-                throw WakewordModelError.filter("\(c.filterModelPath) could not be initialized")
+                throw CommandModelError.filter("\(c.filterModelPath) could not be initialized")
             }
             
             self.encodeModel = try Interpreter(modelPath: c.encodeModelPath)
             if let model = self.encodeModel {
                 try model.allocateTensors()
-                assert(model.inputTensorCount == Tensors.allCases.count)
+                if (model.inputTensorCount != Tensors.allCases.count) {
+                    throw CommandModelError.encode("Wakeword encode model input dimension is \(model.inputTensorCount) which does not matched expected dimension \(Tensors.allCases.count)")
+                }
             } else {
-                throw WakewordModelError.encode("\(c.encodeModelPath) could not be initialized")
+                throw CommandModelError.encode("\(c.encodeModelPath) could not be initialized")
             }
             
             self.detectModel = try Interpreter(modelPath: c.detectModelPath)
             if let model = self.detectModel {
                 try model.allocateTensors()
             } else {
-                throw WakewordModelError.detect("\(c.detectModelPath) could not be initialized")
+                throw CommandModelError.detect("\(c.detectModelPath) could not be initialized")
             }
         } catch let message {
-            self.context.dispatch { $0.failure(error: WakewordModelError.model("TFLiteWakewordRecognizer configureAttentionModels \(message)")) }
+            self.context.dispatch { $0.failure(error: CommandModelError.model("TFLiteWakewordRecognizer configureAttentionModels \(message)")) }
         }
     }
     
@@ -161,7 +161,6 @@ import TensorFlowLite
             self.filterCollector = []
             self.encodeCollector = []
             self.stateCollector = []
-            self.detectCollector = []
         }
         
         // Signal normalization
@@ -172,10 +171,9 @@ import TensorFlowLite
         
         // Sliding window buffers
         self.fftFrame = Array(repeating: 0.0, count: c.fftWindowSize)
-        self.melWidth = c.melFrameWidth
         self.hopLength = c.fftHopLength * c.sampleRate / 1000
         let melLength: Int = c.melFrameLength * c.sampleRate / 1000 / self.hopLength
-        self.frameWindow = RingBuffer(melLength * self.melWidth, repeating: 0.0)
+        self.frameWindow = RingBuffer(melLength * c.melFrameWidth, repeating: 0.0)
         self.sampleWindow = RingBuffer(c.fftWindowSize, repeating: 0.0)
         self.fftWindow = SignalProcessing.fftWindowDispatch(windowType: c.fftWindowType, windowLength: c.fftWindowSize)
         self.fft = FFT(c.fftWindowSize)
@@ -187,7 +185,6 @@ import TensorFlowLite
         self.encodeWindow = RingBuffer(self.encodeLength * c.encodeWidth, repeating: -1.0)
         self.encodeState = RingBuffer(c.stateWidth, repeating: 0.0)
         self.encodeState.fill(0.0)
-        self.detectWindow = RingBuffer(self.encodeLength * c.encodeWidth, repeating: 0.0)
         
         // attention model posteriors
         self.posteriorThreshold = c.wakeThreshold
@@ -198,7 +195,7 @@ import TensorFlowLite
     
     private func sample(_ data: Data) throws -> Void {
         
-        /// Preallocate an array of data elements in the frame for use in RMS and sampling
+        // Preallocate an array of data elements in the frame for use in RMS and sampling
         let dataElements: Array<Int16> = data.elements()
         
         // Update the rms normalization factors
@@ -210,13 +207,12 @@ import TensorFlowLite
         // Process all samples in the frame
         for d in dataElements {
             
-            /// Normalize and clip the 16-bit sample to the target rms energy
+            // Normalize and clip the 16-bit sample to the target rms energy
             var sample: Float = Float(d) / Float(Int16.max)
             sample = sample * (self.rmsTarget / self.rmsValue)
             sample = max(-1.0, min(sample, 1.0))
             
-            // Run a pre-emphasis filter to balance high frequencies
-            /// and eliminate any dc energy
+            // Run a pre-emphasis filter to balance high frequencies and eliminate any dc energy
             let currentSample: Float = sample
             sample -= self.preEmphasis * self.prevSample
             self.prevSample = currentSample
@@ -254,7 +250,7 @@ import TensorFlowLite
             self.fftFrameCollector? += "\(self.fftFrame)\n"
         }
         
-        // send sampleWindow to filter model
+        // send stft spectrogram to filter model
         try self.filter()
     }
     
@@ -262,14 +258,101 @@ import TensorFlowLite
     
     private func filter() throws -> Void {
         do {
-            if let model = self.filterModel {
-                // inputs
-                // compute the manitude of the spectrogram
-                let magnitude = (self.fftFrame.count / 2) + 1
-                // copy the spectrogram into the filter model's input
-                _ = try self
-                    .fftFrame
-                    .prefix(magnitude)
+            guard let model = self.filterModel else {
+                throw CommandModelError.filter("model was not initialized")
+            }
+            // inputs
+            // compute the magnitude of the spectrogram
+            let magnitude = (self.fftFrame.count / 2) + 1
+            // copy the spectrogram into the filter model's input
+            _ = try self
+                .fftFrame
+                .prefix(magnitude)
+                .withUnsafeBytes(
+                    {try model.copy(Data($0), toInputAt: 0)})
+            
+            // calculate
+            try model.invoke()
+            
+            // outputs
+            let output = try model.output(at: 0)
+            let results = output.data.toArray(type: Float32.self, count: output.data.count / 4)
+            self.frameWindow.rewind().seek(self.configuration.melFrameWidth)
+            for r in results {
+                try self.frameWindow.write(r)
+                if self.traceLevel.rawValue <= Trace.Level.DEBUG.rawValue {
+                    self.filterCollector?.append(r)
+                }
+            }
+            
+            // send frameWindow to encoding model
+            try self.encode()
+        } catch let message {
+            throw CommandModelError.filter("TFLiteWakewordRecognizer filter \(message)")
+        }
+    }
+    
+    private func encode() throws -> Void {
+        do {
+            guard let model = self.encodeModel else {
+                throw CommandModelError.encode("model was not initialized")
+            }                // inputs: frameWindow
+            self.frameWindow.rewind()
+            // TODO: model.copy requires that the data be sized to exactly the same as the tensor, so we can't just do read()s off the ringbuffer and copy over piecewise. This introduces an aggrevating overhead of having to copy the ringbuffer into an array before copying over to the tensor. Maybe use a fixed-sized array that is advanced based off the fft frame size?
+            var frameWindowArray: Array<Float32> = []
+            while !self.frameWindow.isEmpty {
+                let f = try self.frameWindow.read()
+                frameWindowArray.append(f)
+            }
+            var stateArray: Array<Float32> = []
+            for _ in 0..<self.stateWidth {
+                let f = try self.encodeState.read()
+                stateArray.append(f)
+            }
+            _ = try frameWindowArray
+                .withUnsafeBytes(
+                    {try model.copy(Data($0), toInputAt: Tensors.encode.rawValue)})
+            _ = try stateArray
+                .withUnsafeBytes(
+                    {try model.copy(Data($0), toInputAt: Tensors.state.rawValue)})
+            
+            // calculate
+            try model.invoke()
+            
+            // outputs
+            let encodeOutput = try model.output(at: Tensors.encode.rawValue)
+            let encodeResults = encodeOutput.data.toArray(type: Float32.self, count: encodeOutput.data.count / 4)
+            self.encodeWindow.rewind().seek(self.encodeWidth)
+            for r in encodeResults {
+                try self.encodeWindow.write(r)
+                if self.traceLevel.rawValue <= Trace.Level.DEBUG.rawValue {
+                    self.encodeCollector?.append(r)
+                }
+            }
+            let stateOutput = try model.output(at: Tensors.state.rawValue)
+            let stateResults = stateOutput.data.toArray(type: Float32.self, count: stateOutput.data.count / 4)
+            for r in stateResults {
+                try self.encodeState.write(r)
+            }
+            
+        } catch let message {
+            throw CommandModelError.filter("TFLiteWakewordRecognizer encode \(message)")
+        }
+    }
+    
+    private func detect() throws -> Bool {
+        if self.encodeWindow.isFull {
+            do {
+                guard let model = self.detectModel else {
+                    throw CommandModelError.encode("model was not initialized")
+                }                    // inputs
+                var encodeWindowArray: Array<Float32> = []
+                self.encodeWindow.rewind()
+                while !self.encodeWindow.isEmpty {
+                    let f = try self.encodeWindow.read()
+                    encodeWindowArray.append(f)
+                }
+                _ = try encodeWindowArray
                     .withUnsafeBytes(
                         {try model.copy(Data($0), toInputAt: 0)})
                 
@@ -277,108 +360,23 @@ import TensorFlowLite
                 try model.invoke()
                 
                 // outputs
-                let output = try model.output(at: 0)
-                let results = output.data.toArray(type: Float32.self, count: output.data.count / 4)
-                self.frameWindow.rewind().seek(self.melWidth)
-                for r in results {
-                    try self.frameWindow.write(r)
-                    if self.traceLevel.rawValue <= Trace.Level.DEBUG.rawValue {
-                        self.filterCollector?.append(r)
-                    }
-                }
+                let detectOutput = try model.output(at: 0)
+                let detectResults = detectOutput.data.toArray(type: Float32.self, count: detectOutput.data.count / 4)
+                let posterior = detectResults[0]
                 
-                // send frameWindow to encoding model
-                try self.encode()
-            } else {
-                throw WakewordModelError.filter("model was not initialized")
-            }
-        } catch let message {
-            throw WakewordModelError.filter("TFLiteWakewordRecognizer filter \(message)")
-        }
-    }
-    
-    private func encode() throws -> Void {
-        do {
-            if let model = self.encodeModel {
-                // inputs
-                self.frameWindow.rewind()
-                // TODO: model.copy requires that the data be sized to exactly the same as the tensor, so we can't just do read()s off the ringbuffer and copy over piecewise. This introduces an aggrevating overhead of having to copy the ringbuffer into an array before copying over to the tensor. Maybe use a fixed-sized array that is advanced based off the fft frame size?
-                var frameWindowArray: Array<Float32> = []
-                while !self.frameWindow.isEmpty {
-                    let f = try self.frameWindow.read()
-                    frameWindowArray.append(f)
-                }
-                var stateArray: Array<Float32> = []
-                for _ in 0..<self.stateWidth {
-                    let f = try self.encodeState.read()
-                    stateArray.append(f)
-                }
-                _ = try frameWindowArray
-                    .withUnsafeBytes(
-                        {try model.copy(Data($0), toInputAt: Tensors.encode.rawValue)})
-                _ = try stateArray
-                    .withUnsafeBytes(
-                        {try model.copy(Data($0), toInputAt: Tensors.state.rawValue)})
-                
-                // calculate
-                try model.invoke()
-                
-                // outputs
-                let encodeOutput = try model.output(at: Tensors.encode.rawValue)
-                let encodeResults = encodeOutput.data.toArray(type: Float32.self, count: encodeOutput.data.count / 4)
-                self.encodeWindow.rewind().seek(self.encodeWidth)
-                for r in encodeResults {
-                    try self.encodeWindow.write(r)
-                    if self.traceLevel.rawValue <= Trace.Level.DEBUG.rawValue {
-                        self.encodeCollector?.append(r)
-                    }
-                }
-                let stateOutput = try model.output(at: Tensors.state.rawValue)
-                let stateResults = stateOutput.data.toArray(type: Float32.self, count: stateOutput.data.count / 4)
-                for r in stateResults {
-                    try self.encodeState.write(r)
-                }
-            } else {
-                throw WakewordModelError.encode("model was not initialized")
-            }
-        }
-    }
-    
-    private func detect() throws -> Bool {
-        if self.encodeWindow.isFull {
-            do {
-                if let model = self.detectModel {
-                    // inputs
-                    var encodeWindowArray: Array<Float32> = []
-                    self.encodeWindow.rewind()
-                    while !self.encodeWindow.isEmpty {
-                        let f = try self.encodeWindow.read()
-                        encodeWindowArray.append(f)
-                    }
-                    _ = try encodeWindowArray
-                        .withUnsafeBytes(
-                            {try model.copy(Data($0), toInputAt: 0)})
-                    
-                    // calculate
-                    try model.invoke()
-                    
-                    // outputs
-                    let detectOutput = try model.output(at: 0)
-                    let detectResults = detectOutput.data.toArray(type: Float32.self, count: detectOutput.data.count / 4)
-                    let posterior = detectResults[0]
-                    
-                    if let pmax = self.posteriorMax {
-                        if self.traceLevel.rawValue < Trace.Level.INFO.rawValue {
-                            if posterior > pmax {
-                                self.posteriorMax = posterior
-                            }
+                if let pmax = self.posteriorMax {
+                    if self.traceLevel.rawValue < Trace.Level.INFO.rawValue {
+                        if posterior > pmax {
+                            self.posteriorMax = posterior
                         }
                     }
-                    
-                    if posterior > self.posteriorThreshold {
-                        return true
-                    }
                 }
+                
+                if posterior > self.posteriorThreshold {
+                    return true
+                }
+            } catch let message {
+                throw CommandModelError.detect("TFLiteWakewordRecognizer detect \(message)")
             }
         }
         return false
@@ -394,7 +392,6 @@ import TensorFlowLite
         self.frameWindow.reset().fill(0)
         self.encodeWindow.reset().fill(-1.0)
         self.encodeState.reset().fill(0)
-        self.detectWindow.reset().fill(0)
         
         // reset the maximum posterior
         self.posteriorMax = 0
@@ -453,7 +450,7 @@ extension TFLiteWakewordRecognizer : SpeechProcessor {
                     } catch let error {
                         strongSelf.context.dispatch { $0.failure(error: error) }
                     }
-                // vad detection edge
+                    // vad detection edge
                 } else if strongSelf.isSpeechDetected {
                     strongSelf.reset()
                 }

--- a/Spokestack/TFLiteWakewordRecognizer.swift
+++ b/Spokestack/TFLiteWakewordRecognizer.swift
@@ -438,7 +438,7 @@ extension TFLiteWakewordRecognizer : SpeechProcessor {
                     } catch let error {
                         strongSelf.context.dispatch { $0.failure(error: error) }
                     }
-                    // vad detection edge
+                // vad detection edge
                 } else if strongSelf.isSpeechDetected {
                     strongSelf.reset()
                 }

--- a/SpokestackFrameworkExample/Base.lproj/Main.storyboard
+++ b/SpokestackFrameworkExample/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -15,7 +16,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QGK-UT-G0J" userLabel="Spokestack ASR Button">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QGK-UT-G0J" userLabel="Spokestack ASR Button">
                                 <rect key="frame" x="131" y="80" width="113" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Spokestack ASR"/>
@@ -23,7 +24,7 @@
                                     <action selector="spokestackASRAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="J6n-by-V4I"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="N81-j7-Wc3" userLabel="Apple ASR Button">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="N81-j7-Wc3" userLabel="Apple ASR Button">
                                 <rect key="frame" x="151" y="118" width="73" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Apple ASR"/>
@@ -31,7 +32,7 @@
                                     <action selector="appleASRAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LVX-mL-WpS"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ewK-ye-p0o" userLabel="Apple Wakeword Button">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ewK-ye-p0o" userLabel="Apple Wakeword Button">
                                 <rect key="frame" x="130" y="156" width="115" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Apple Wakeword"/>
@@ -39,7 +40,7 @@
                                     <action selector="appleWakewordAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="PBl-wH-ng0"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kmz-5x-JBe" userLabel="TensorFlow Wakeword Button">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kmz-5x-JBe" userLabel="TensorFlow Wakeword Button">
                                 <rect key="frame" x="110" y="194" width="154" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="TensorFlow Wakeword"/>
@@ -47,7 +48,7 @@
                                     <action selector="tensorFlowWakewordAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uuB-4p-fK8"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6e2-y1-L2l" userLabel="TTS Button">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6e2-y1-L2l" userLabel="TTS Button">
                                 <rect key="frame" x="136" y="232" width="103" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Text to Speech"/>
@@ -55,7 +56,7 @@
                                     <action selector="ttsAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="srU-eY-u4B"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vDe-F7-1Hu" userLabel="NLU Button">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vDe-F7-1Hu" userLabel="NLU Button">
                                 <rect key="frame" x="172" y="270" width="30" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="NLU"/>
@@ -63,9 +64,17 @@
                                     <action selector="nluAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="tkp-Xi-EaQ"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5bk-t0-Mdq" userLabel="TensorFlow Keyword Button">
+                                <rect key="frame" x="116" y="308" width="142" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="TensorFlow Keyword"/>
+                                <connections>
+                                    <action selector="keywordAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="y11-yo-mW8"/>
+                                </connections>
+                            </button>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                     <connections>
                         <outlet property="appleASRButton" destination="N81-j7-Wc3" id="Fa8-H3-fS1"/>

--- a/SpokestackFrameworkExample/KeywordDetect.tflite
+++ b/SpokestackFrameworkExample/KeywordDetect.tflite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b0b7d86027d871ca35a2eca34270428cab8746e762f71a53285d578124b2878
+size 85460

--- a/SpokestackFrameworkExample/KeywordEncode.tflite
+++ b/SpokestackFrameworkExample/KeywordEncode.tflite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27334fbda4f09a584ac3fd2516487abe246eea90ef0cb6be9609e4590bd437ad
+size 696288

--- a/SpokestackFrameworkExample/KeywordFilter.tflite
+++ b/SpokestackFrameworkExample/KeywordFilter.tflite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c931cabd8d6a95ecf9d23c0cf9c3e44a5fc748347bef4eaacc1f50a4975fb22
+size 42708

--- a/SpokestackFrameworkExample/TFLiteKeywordViewController.swift
+++ b/SpokestackFrameworkExample/TFLiteKeywordViewController.swift
@@ -44,15 +44,7 @@ class TFLiteKeywordViewController: UIViewController {
         return button
     }()
     
-    lazy private var pipeline: SpeechPipeline = {
-        return try! SpeechPipelineBuilder()
-            .addListener(self)
-            .useProfile(.vadTriggerSpokestackSpeech)
-            .setProperty("tracing", ".DEBUG")
-            .setProperty("vadFallDelay", "1600")
-            .setDelegateDispatchQueue(DispatchQueue.main)
-            .build()
-    }()
+    private var pipeline: SpeechPipeline?
     
     override func loadView() {
         
@@ -104,6 +96,7 @@ class TFLiteKeywordViewController: UIViewController {
             .useProfile(.vadTriggerKeyword)
             .setProperty("tracing", Trace.Level.PERF)
             .setProperty("keywordDetectModelPath", detectPath)
+            .setProperty("keywords", "bed,bird,cat,dog,down,eight,five,four,go,happy,house,left,marvin,nine,no,off,on,one,right,seven,sheila,six,stop,three,tree,two,up,wow,yes,zero")
             .setProperty("keywordEncodeModelPath", encodePath)
             .setProperty("keywordFilterModelPath", filterPath)
             .build()
@@ -111,12 +104,12 @@ class TFLiteKeywordViewController: UIViewController {
     
     @objc func startRecordingAction(_ sender: Any) {
         print("pipeline started")
-        self.pipeline.start()
+        self.pipeline?.start()
     }
     
     @objc func stopRecordingAction(_ sender: Any) {
         print("pipeline finished")
-        self.pipeline.stop()
+        self.pipeline?.stop()
     }
     
     @objc func dismissViewController(_ sender: Any?) -> Void {

--- a/SpokestackFrameworkExample/TFLiteKeywordViewController.swift
+++ b/SpokestackFrameworkExample/TFLiteKeywordViewController.swift
@@ -1,63 +1,85 @@
 //
-//  TFLiteViewController.swift
+//  TFLiteKeywordViewController.swift
 //  SpokestackFrameworkExample
 //
-//  Created by Noel Weichbrodt on 8/12/19.
+//  Created by Noel Weichbrodt on 12/10/20.
 //  Copyright © 2020 Spokestack, Inc. All rights reserved.
 //
 
+import Foundation
 import UIKit
 import Spokestack
 import AVFoundation
 
-class TFLiteViewController: UIViewController {
+class TFLiteKeywordViewController: UIViewController {
     
     lazy var startRecordingButton: UIButton = {
+        
         let button: UIButton = UIButton(frame: .zero)
+        
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle("Start", for: .normal)
         button.addTarget(self,
-                         action: #selector(TFLiteViewController.startRecordingAction(_:)),
+                         action: #selector(TFLiteKeywordViewController.startRecordingAction(_:)),
                          for: .touchUpInside)
-        button.setTitleColor(.purple, for: .normal)
-        button.isEnabled = true
+        
+        button.setTitleColor(.blue, for: .normal)
+        
         return button
     }()
     
     var stopRecordingButton: UIButton = {
+        
         let button: UIButton = UIButton(frame: .zero)
+        
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle("Stop", for: .normal)
         button.addTarget(self,
-                         action: #selector(TFLiteViewController.stopRecordingAction(_:)),
+                         action: #selector(TFLiteKeywordViewController.stopRecordingAction(_:)),
                          for: .touchUpInside)
-        button.setTitleColor(.purple, for: .normal)
-        button.isEnabled = false
+        
+        button.setTitleColor(.blue, for: .normal)
+        
+        
         return button
     }()
     
-    private var pipeline: SpeechPipeline?
+    lazy private var pipeline: SpeechPipeline = {
+        return try! SpeechPipelineBuilder()
+            .addListener(self)
+            .useProfile(.vadTriggerSpokestackSpeech)
+            .setProperty("tracing", ".DEBUG")
+            .setProperty("vadFallDelay", "1600")
+            .setDelegateDispatchQueue(DispatchQueue.main)
+            .build()
+    }()
     
     override func loadView() {
+        
         super.loadView()
         self.view.backgroundColor = .white
-        self.title = "TensorFlow Wakeword"
+        self.title = "Keyword Recognizer"
+        
         let doneBarButtonItem: UIBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done,
                                                                  target: self,
-                                                                 action: #selector(TFLiteViewController.dismissViewController(_:)))
+                                                                 action: #selector(TFLiteKeywordViewController.dismissViewController(_:)))
         self.navigationItem.rightBarButtonItem = doneBarButtonItem
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         self.view.addSubview(self.startRecordingButton)
         self.view.addSubview(self.stopRecordingButton)
+        
         self.startRecordingButton.centerYAnchor.constraint(equalTo: self.view.centerYAnchor).isActive = true
         self.startRecordingButton.leftAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leftAnchor).isActive = true
         self.startRecordingButton.rightAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.rightAnchor).isActive = true
+        
         self.stopRecordingButton.topAnchor.constraint(equalTo: self.startRecordingButton.bottomAnchor, constant: 50.0).isActive = true
         self.stopRecordingButton.leftAnchor.constraint(equalTo: self.startRecordingButton.leftAnchor).isActive = true
         self.stopRecordingButton.rightAnchor.constraint(equalTo: self.startRecordingButton.rightAnchor).isActive = true
+        
         do {
             self.pipeline = try self.initPipeline()
         } catch let error {
@@ -67,47 +89,42 @@ class TFLiteViewController: UIViewController {
     
     func initPipeline() throws -> SpeechPipeline {
         let c = SpeechConfiguration()
-        guard let filterPath = Bundle(for: type(of: self)).path(forResource: c.filterModelName, ofType: "lite") else {
-            throw CommandModelError.filter("could not find \(c.filterModelName).lite in bundle \(self.debugDescription)")
+        guard let filterPath = Bundle(for: type(of: self)).path(forResource: c.keywordFilterModelName, ofType: "tflite") else {
+            throw CommandModelError.filter("could not find \(c.keywordFilterModelName).tflite in bundle \(self.debugDescription)")
         }
-        guard let encodePath = Bundle(for: type(of: self)).path(forResource: c.encodeModelName, ofType: "lite") else {
-            throw CommandModelError.encode("could not find \(c.encodeModelName).lite in bundle \(self.debugDescription)")
+        guard let encodePath = Bundle(for: type(of: self)).path(forResource: c.keywordEncodeModelName, ofType: "tflite") else {
+            throw CommandModelError.encode("could not find \(c.keywordEncodeModelName).tflite in bundle \(self.debugDescription)")
         }
-        guard let detectPath = Bundle(for: type(of: self)).path(forResource: c.detectModelName, ofType: "lite") else {
-            throw CommandModelError.detect("could not find \(c.detectModelName).lite in bundle \(self.debugDescription)")
+        guard let detectPath = Bundle(for: type(of: self)).path(forResource: c.keywordDetectModelName, ofType: "tflite") else {
+            throw CommandModelError.detect("could not find \(c.keywordDetectModelName).tflite in bundle \(self.debugDescription)")
         }
         return try! SpeechPipelineBuilder()
             .addListener(self)
             .setDelegateDispatchQueue(DispatchQueue.main)
-            .useProfile(.tfLiteWakewordAppleSpeech)
+            .useProfile(.vadTriggerKeyword)
             .setProperty("tracing", Trace.Level.PERF)
-            .setProperty("detectModelPath", detectPath)
-            .setProperty("encodeModelPath", encodePath)
-            .setProperty("filterModelPath", filterPath)
+            .setProperty("keywordDetectModelPath", detectPath)
+            .setProperty("keywordEncodeModelPath", encodePath)
+            .setProperty("keywordFilterModelPath", filterPath)
             .build()
     }
     
     @objc func startRecordingAction(_ sender: Any) {
         print("pipeline started")
-        self.pipeline?.start()
+        self.pipeline.start()
     }
     
     @objc func stopRecordingAction(_ sender: Any) {
         print("pipeline finished")
-        self.pipeline?.stop()
+        self.pipeline.stop()
     }
     
     @objc func dismissViewController(_ sender: Any?) -> Void {
         self.dismiss(animated: true, completion: nil)
     }
-    
-    func toggleStartStop() {
-        self.stopRecordingButton.isEnabled.toggle()
-        self.startRecordingButton.isEnabled.toggle()
-    }
 }
 
-extension TFLiteViewController: SpokestackDelegate {
+extension TFLiteKeywordViewController: SpokestackDelegate {
     
     func setupFailed(_ error: String) {
         print("setupFailed: " + error)
@@ -117,16 +134,24 @@ extension TFLiteViewController: SpokestackDelegate {
         print("didInit")
     }
     
+    func didStop() {
+        print("didStop")
+    }
+    
     func didTimeout() {
         print("timeout")
     }
     
     func didActivate() {
         print("didActivate")
+        self.stopRecordingButton.isEnabled.toggle()
+        self.startRecordingButton.isEnabled.toggle()
     }
     
     func didDeactivate() {
         print("didDeactivate")
+        self.stopRecordingButton.isEnabled.toggle()
+        self.startRecordingButton.isEnabled.toggle()
     }
     
     func failure(error: Error) {
@@ -137,18 +162,17 @@ extension TFLiteViewController: SpokestackDelegate {
         print("didRecognize transcript \(result.transcript)")
     }
     
-    func didStart() {
-        print("didStart")
-        self.toggleStartStop()
+    func didRecognizePartial(_ result: SpeechContext) {
+        print("didRecognizePartial transcript \(result.transcript)")
     }
     
-    func didStop() {
-        print("didStop")
-        self.toggleStartStop()
+    func didStart() {
+        print("didStart")
+        self.stopRecordingButton.isEnabled.toggle()
+        self.startRecordingButton.isEnabled.toggle()
     }
     
     func didTrace(_ trace: String) {
         print("didTrace: \(trace)")
     }
 }
-

--- a/SpokestackFrameworkExample/ViewController.swift
+++ b/SpokestackFrameworkExample/ViewController.swift
@@ -74,6 +74,13 @@ class ViewController: UIViewController {
         
         self.present(navigationViewController, animated: true, completion: nil)
     }
+
+    @IBAction func keywordAction(_ sender: Any) {
+        let controller: TFLiteKeywordViewController = TFLiteKeywordViewController()
+        let navigationViewController: UINavigationController = UINavigationController(rootViewController: controller)
+        
+        self.present(navigationViewController, animated: true, completion: nil)
+    }
     
     @objc func dismissViewController(_ sender: Any?) -> Void {
         self.dismiss(animated: true, completion: nil)

--- a/SpokestackTests/RingBufferTest.swift
+++ b/SpokestackTests/RingBufferTest.swift
@@ -40,6 +40,7 @@ class RingBufferTest: XCTestCase {
             thrownError = $0
             XCTAssert($0.localizedDescription.count > 1)
         }
+        XCTAssertTrue(buffer3.isEmpty)
         XCTAssert(thrownError is RingBufferStateError, "unexpected error type \(type(of: thrownError)) during read()")
         
         // single read/write

--- a/SpokestackTests/TFLiteKeywordRecognizerTest.swift
+++ b/SpokestackTests/TFLiteKeywordRecognizerTest.swift
@@ -152,7 +152,7 @@ class TFLiteKeywordecognizerTestDelegate: SpokestackDelegate {
     func failure(error: Error) {
         print(error)
         guard let _ = asyncExpectation else {
-            XCTFail("TFLiteKeywordecognizerTestDelegate was not setup correctly. Missing XCTExpectation reference")
+            XCTFail("TFLiteKeywordRecognizerTestDelegate was not setup correctly. Missing XCTExpectation reference")
             return
         }
         self.didError = true

--- a/SpokestackTests/TFLiteKeywordRecognizerTest.swift
+++ b/SpokestackTests/TFLiteKeywordRecognizerTest.swift
@@ -1,0 +1,197 @@
+//
+//  TFLiteKeywordRecognizerTest.swift
+//  SpokestackTests
+//
+//  Created by Noel Weichbrodt on 12/14/20.
+//  Copyright © 2020 Spokestack, Inc. All rights reserved.
+//
+
+import Foundation
+import CryptoKit
+@testable import TensorFlowLite
+@testable import Spokestack
+import XCTest
+
+class TFLiteKeywordRecognizerTest: XCTestCase {
+    let delegate = TFLiteKeywordecognizerTestDelegate()
+    let config = SpeechConfiguration()
+    var context: SpeechContext?
+    var recognizer: TFLiteKeywordRecognizer?
+    
+    override func setUp() {
+        self.config.keywordEncodeModelPath = MockKeywordModels.encodePath
+        self.config.keywordFilterModelPath = MockKeywordModels.filterPath
+        self.config.keywordDetectModelPath = MockKeywordModels.detectPath
+        self.context = SpeechContext(config)
+        //self.config.wakeActiveMin = 20
+        //self.config.wakeActiveMax = 100
+        //self.config.keywordMelFrameWidth = 1
+        self.config.keywordMelFrameLength = 16
+        //self.config.keywordEncodeLength = 1
+        self.recognizer = TFLiteKeywordRecognizer(config, context: self.context!)
+    }
+    
+    func testInvoke() {
+        // filter
+        let filter = try! Interpreter(modelPath: MockKeywordModels.filterPath)
+        try! filter.allocateTensors()
+        _ = MockKeywordModels.filterInput.withUnsafeBytes { try! filter.copy(Data($0), toInputAt: 0) }
+        _ = try! filter.invoke()
+        let filterOutput = try! filter.output(at: MockKeywordModels.validIndex)
+        XCTAssertEqual(filterOutput.data, MockKeywordModels.filterOutputData)
+        let filterResult = filterOutput.data.toArray(type: Int32.self, count: filterOutput.data.count/4)
+        XCTAssertEqual(filterResult, MockKeywordModels.filterOutput)
+        
+        // encode
+        let encoder = try! Interpreter(modelPath: MockKeywordModels.encodePath)
+        try! encoder.allocateTensors()
+        _ = MockKeywordModels.encodeInput.withUnsafeBytes { try! encoder.copy(Data($0), toInputAt: 0) }
+        _ = MockKeywordModels.input.withUnsafeBytes { try! encoder.copy(Data($0), toInputAt: 1) }
+        _ = try! encoder.invoke()
+        let encoderOutput = try! encoder.output(at: MockKeywordModels.validIndex)
+        XCTAssertEqual(encoderOutput.data, MockKeywordModels.encodeOutputData)
+        let encoderResult = encoderOutput.data.toArray(type: Int32.self, count: encoderOutput.data.count/4)
+        XCTAssertEqual(encoderResult, MockKeywordModels.encodeOutput)
+        
+        // detect
+        let detect = try! Interpreter(modelPath: MockKeywordModels.detectPath)
+        try! detect.allocateTensors()
+        _ = MockKeywordModels.detectInput.withUnsafeBytes { try! detect.copy(Data($0), toInputAt: 0) }
+        _ = try! detect.invoke()
+        let detectOutput = try! detect.output(at: MockKeywordModels.validIndex)
+        XCTAssertEqual(detectOutput.data, MockKeywordModels.detectOutputData)
+        let detectResult = detectOutput.data.toArray(type: Int32.self, count: detectOutput.data.count/4)
+        XCTAssertEqual(detectResult, MockKeywordModels.detectOutput)
+    }
+    
+    func testStartStop() {
+        self.context!.isActive = false
+        self.recognizer?.startStreaming()
+        self.recognizer?.stopStreaming()
+    }
+    
+    func testProcess() {
+        // setup
+        self.recognizer?.context.addListener(self.delegate)
+        self.recognizer?.context.isActive = true
+        self.recognizer?.context.isSpeech = true
+        self.recognizer?.startStreaming()
+        let recognizeExpectation = XCTestExpectation(description: "process without failure.")
+        let timeoutExpectation = XCTestExpectation(description: "process without failure.")
+        let failureExpectation = XCTestExpectation(description: "process without failure.")
+        self.delegate.asyncExpectation = failureExpectation
+        self.delegate.didRecognizeExepctation = recognizeExpectation
+        self.delegate.didTimeoutExpectation = timeoutExpectation
+        
+        // timeout
+        for _ in 0...1 {
+            self.recognizer?.process(Frame.voice(frameWidth: 20, sampleRate: 16000))
+        }
+        self.context?.isActive = false
+        wait(for: [timeoutExpectation], timeout: 1)
+        XCTAssert(self.delegate.timedOut)
+        XCTAssertFalse(self.delegate.didError)
+        XCTAssertFalse(self.delegate.recognized)
+        
+        // don't process if the pipeline isn't active
+        delegate.reset()
+        self.recognizer?.startStreaming()
+        self.recognizer?.context.isSpeech = true
+        self.recognizer?.context.isActive = false
+        self.delegate.didTimeoutExpectation = timeoutExpectation
+        self.delegate.didRecognizeExepctation = recognizeExpectation
+        for _ in 0...1 {
+            self.recognizer?.process(Frame.silence(frameWidth: 20, sampleRate: 8000))
+        }
+        XCTAssertFalse(self.recognizer!.context.isActive)
+        XCTAssertFalse(self.delegate.timedOut)
+        XCTAssertFalse(self.delegate.recognized)
+        XCTAssertFalse(self.delegate.didError)
+    }
+}
+
+fileprivate enum MockKeywordModels {
+    static let filterInfo = (name: "mock_kw_filter", extension: "tflite")
+    static let encodeInfo = (name: "mock_kw_encode", extension: "tflite")
+    static let detectInfo = (name: "mock_kw_detect", extension: "tflite")
+    static var filterPath: String = {
+        let bundle = Bundle(for: TFLiteKeywordRecognizerTest.self)
+        let p = bundle.path(forResource: filterInfo.name, ofType: filterInfo.extension)
+        return p!
+    }()
+    static var encodePath: String = {
+        let bundle = Bundle(for: TFLiteKeywordRecognizerTest.self)
+        let p = bundle.path(forResource: encodeInfo.name, ofType: encodeInfo.extension)
+        return p!
+    }()
+    static var detectPath: String = {
+        let bundle = Bundle(for: TFLiteKeywordRecognizerTest.self)
+        let p = bundle.path(forResource: detectInfo.name, ofType: detectInfo.extension)
+        return p!
+    }()
+    static let input = [Int32](Array(repeating: 0, count: 128)).withUnsafeBufferPointer(Data.init)
+    static let filterInput = [Int32](Array(repeating: 0, count: 257)).withUnsafeBufferPointer(Data.init)
+    static let encodeInput = [Int32](Array(repeating: 0, count: 40)).withUnsafeBufferPointer(Data.init)
+    static let detectInput = [Int32](Array(repeating: 0, count: 11776)).withUnsafeBufferPointer(Data.init)
+    static let validIndex = 0
+    static let shape: Tensor.Shape = [2]
+    static let output = [Int32](Array(repeating: 0, count: 40))
+    static let outputData = output.withUnsafeBufferPointer(Data.init)
+    static let filterOutput = [Int32](Array(repeating: 0, count: 40))
+    static let filterOutputData = filterOutput.withUnsafeBufferPointer(Data.init)
+    static let encodeOutput = [Int32](Array(repeating: 0, count: 128))
+    static let encodeOutputData = encodeOutput.withUnsafeBufferPointer(Data.init)
+    static let detectOutput = [Int32](arrayLiteral: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    static let detectOutputData = detectOutput.withUnsafeBufferPointer(Data.init)
+}
+
+class TFLiteKeywordecognizerTestDelegate: SpokestackDelegate {
+    var didError: Bool = false
+    var recognized: Bool = false
+    var timedOut: Bool = false
+    var asyncExpectation: XCTestExpectation?
+    var didRecognizeExepctation: XCTestExpectation?
+    var didTimeoutExpectation: XCTestExpectation?
+    
+    func failure(error: Error) {
+        print(error)
+        guard let _ = asyncExpectation else {
+            XCTFail("TFLiteKeywordecognizerTestDelegate was not setup correctly. Missing XCTExpectation reference")
+            return
+        }
+        self.didError = true
+        self.asyncExpectation?.fulfill()
+    }
+    
+    func reset() {
+        self.didError = false
+        self.recognized = false
+        self.timedOut = false
+        self.asyncExpectation = .none
+        self.didRecognizeExepctation = .none
+        self.didTimeoutExpectation = .none
+    }
+    
+    func didRecognize(_ result: SpeechContext) {
+        print(result)
+        guard let _ = didRecognizeExepctation else {
+            XCTFail("TFLiteKeywordecognizerTestDelegate was not setup correctly. Missing XCTExpectation reference")
+            return
+        }
+        self.recognized = true
+        self.didRecognizeExepctation?.fulfill()
+    }
+    
+    func didTimeout() {
+        guard let _ = didTimeoutExpectation else {
+            XCTFail("TFLiteKeywordecognizerTestDelegate was not setup correctly. Missing XCTExpectation reference")
+            return
+        }
+        self.timedOut = true
+        self.didTimeoutExpectation?.fulfill()
+    }
+    
+    func didTrace(_ trace: String) {
+        print(trace)
+    }
+}

--- a/SpokestackTests/TFLiteKeywordRecognizerTest.swift
+++ b/SpokestackTests/TFLiteKeywordRecognizerTest.swift
@@ -23,11 +23,7 @@ class TFLiteKeywordRecognizerTest: XCTestCase {
         self.config.keywordFilterModelPath = MockKeywordModels.filterPath
         self.config.keywordDetectModelPath = MockKeywordModels.detectPath
         self.context = SpeechContext(config)
-        //self.config.wakeActiveMin = 20
-        //self.config.wakeActiveMax = 100
-        //self.config.keywordMelFrameWidth = 1
         self.config.keywordMelFrameLength = 16
-        //self.config.keywordEncodeLength = 1
         self.recognizer = TFLiteKeywordRecognizer(config, context: self.context!)
     }
     

--- a/SpokestackTests/TFLiteWakewordRecognizerTest.swift
+++ b/SpokestackTests/TFLiteWakewordRecognizerTest.swift
@@ -44,7 +44,6 @@ class TFLiteWakewordRecognizerTest: XCTestCase {
         self.context = SpeechContext(config)
 
         self.tflwr = TFLiteWakewordRecognizer(config, context: self.context!)
-        self.tflwr?.context = context!
         //let filterHexString = filter.map { String(format: "%02hhx", $0) }.joined()
         //let filterData = hexStringToData(hexString: MockWakewordModels.filterString)
         //let _ = FileManager.default.createFile(atPath: MockWakewordModels.filterPath, contents: filterData, attributes: .none)
@@ -97,8 +96,10 @@ class TFLiteWakewordRecognizerTest: XCTestCase {
         self.tflwr?.context.isActive = false
         self.tflwr?.context.isSpeech = true
         self.tflwr?.startStreaming()
+        let failureExpectation = XCTestExpectation(description: "process without failure.")
         let activateExpectation = XCTestExpectation(description: "process without failure.")
         let deactivateMaxActiveExpectation = XCTestExpectation(description: "process without failure.")
+        self.delegate.asyncExpectation = failureExpectation
         self.delegate.didActivateExpectation = activateExpectation
         
         // activate

--- a/SpokestackTests/mock_kw_detect.tflite
+++ b/SpokestackTests/mock_kw_detect.tflite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6d3f7b2765aa1a1102c341f9c23653191bc0572ac6750458ae8bff1a828ae50
+size 1268

--- a/SpokestackTests/mock_kw_encode.tflite
+++ b/SpokestackTests/mock_kw_encode.tflite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae313a0412176a3862d88f8c2e369e24452d24583bb639dea2e503d0f34da7a6
+size 1000

--- a/SpokestackTests/mock_kw_filter.tflite
+++ b/SpokestackTests/mock_kw_filter.tflite
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f59e177a4bcd1f30c40ba865ebd1bcc672f0a515463d81236eb98e464943dd6a
+size 576


### PR DESCRIPTION
Adds support for on-device keyword recognition as an additional stage in the speech pipeline, with associated tests and reference implementation. The copypasta from on-device wakeword suggested a small number of internal improvements to both recognizers, hence the changes in `TFLiteWakewordRecognizer.swift`-associated files. Additionally, a set of mock and example keyword models are included for testing and reference use, respectively, in keeping with the practice established by the wakeword recognizer.

A small bug was fixed in the `RingBuffer` class to address allowing a `read` to continue after knowing it would fail.

Sibling of https://github.com/spokestack/spokestack-android/pull/95