### PR TITLE
Apple recognizer concurrency fixes

### DIFF
--- a/Spokestack/SpeechConfiguration.swift
+++ b/Spokestack/SpeechConfiguration.swift
@@ -94,9 +94,6 @@ import Foundation
     /// The filesystem path to the machine learning model for the detect step.
     /// - SeeAlso: `TFLiteWakewordRecognizer`
     @objc public var detectModelPath: String = "Detect.lite"
-    /// Text To Speech API authorization key
-    @available(*, deprecated, message: "Authorization key is no longer supported for Text To Speech service, use apiId + apiKey instead.")
-    @objc public var authorization: String = "Key f854fbf30a5f40c189ecb1b38bc78059"
     /// Text To Speech API client identifier key.
     /// - SeeAlso: `TextToSpeech`
     @objc public var apiId: String = "f0bc990c-e9db-4a0c-a2b1-6a6395a3d97e"

--- a/Spokestack/SpeechConfiguration.swift
+++ b/Spokestack/SpeechConfiguration.swift
@@ -181,4 +181,8 @@ import Foundation
     /// The length of the sliding window of encoder output used as an input to the wakeword recognizer classifier, in milliseconds.
     /// - SeeAlso: `TFLiteWakewordRecognizer`
     @objc public var keywordEncodeLength: Int = 920
+    /// Timeout in seconds used for semaphore waits in the speech pipeline
+    /// - Warning: There is not normally a need to change this value.
+    /// - SeeAlso: `AudioController`, `AppleWakewordRecognizer`, `AppleSpeechRecognizer`
+    @objc public var semaphoreTimeout: Double = 1
 }

--- a/SpokestackFrameworkExample/TTSViewController.swift
+++ b/SpokestackFrameworkExample/TTSViewController.swift
@@ -227,7 +227,7 @@ extension TTSViewController {
     private func TICK() { startTime = CACurrentMediaTime() }
     private func TOCK(function: String = #function, file: String = #file, line: Int = #line, level: Trace.Level = .PERF){
         if self.configuration.tracing.rawValue <= Trace.Level.PERF.rawValue {
-            print("\(function) Time: \(CACurrentMediaTime()-startTime)\nLine:\(line) File: \(file)")
+            print("\(self) \(function) Time: \(CACurrentMediaTime()-startTime)\nLine:\(line) File: \(file)")
         }
     }
     
@@ -317,6 +317,7 @@ extension TTSViewController: SpokestackDelegate {
         guard let url = result.url else {
             return
         }
+        print("success \(url)")
         self.streamingFile = url
         if (self.amTesting) {
             self.playTest()
@@ -334,12 +335,10 @@ extension TTSViewController: SpokestackDelegate {
     }
     
     func failure(error: Error) {
-        print(error)
+        print("error \(error)")
     }
     
     func didTrace(_ trace: String) {
-        print(trace)
+        print("trace \(trace)")
     }
-    
-    
 }


### PR DESCRIPTION
Suggested by https://github.com/spokestack/spokestack-ios/compare/14.0.3...xaphod:xaphod/14.0.3 as fixes for #109 & #110.

Memory usage is now constant, and repeated simulator runs suggest the concurrency issues wrt `AudioEngine` are no longer impacting usage.

Also, some minor code changes and comments to help future debugging in `TextToSpeech`