### PR TITLE
fix: pipeline profiles enum now matches order expected by react-native-spokestack

### DIFF
--- a/Spokestack/SpeechProcessor.swift
+++ b/Spokestack/SpeechProcessor.swift
@@ -51,26 +51,26 @@ internal enum SpeechProcessors: Int {
 
 /// Profiles that may be passed to `SpeechPipelineBuilder` for easy pipeline configuring.
 @objc public enum SpeechPipelineProfiles: Int {
-    /// VAD-sensitive Apple wakeword activates Apple ASR
-    case appleWakewordAppleSpeech
     /// VAD-sensitive TFLiteWakeword activates Apple ASR
     case tfLiteWakewordAppleSpeech
     /// VAD-triggered Apple ASR
     case vadTriggerAppleSpeech
     /// Apple ASR that is manually activated and deactivated
     case pushToTalkAppleSpeech
-    /// VAD-triggered Spokestack ASR
-    case vadTriggerSpokestackSpeech
     /// VAD-sensitive TFLiteWakeword activates Spokestack ASR
     case tfLiteWakewordSpokestackSpeech
+    /// VAD-triggered Spokestack ASR
+    case vadTriggerSpokestackSpeech
     /// Spokestack ASR that is manually activated and deactivated
     case pushToTalkSpokestackSpeech
-    /// VAD-sensitive Apple wakeword activates TFLite Keyword Recognizer
-    case appleWakewordKeyword
     /// VAD-sensitive TFLiteWakeword activates TFLite Keyword Recognizer
     case tfLiteWakewordKeyword
     /// VAD-triggered TFLite Keyword Recognizer
     case vadTriggerKeyword
+    /// VAD-sensitive Apple wakeword activates Apple ASR
+    case appleWakewordAppleSpeech
+    /// VAD-sensitive Apple wakeword activates TFLite Keyword Recognizer
+    case appleWakewordKeyword
 }
 
 extension SpeechPipelineProfiles {


### PR DESCRIPTION
* Improve objc bridge ergonomics for pipeline profiles enum.